### PR TITLE
(Another) preauth event fix

### DIFF
--- a/Exiled.Events/Patches/Events/Player/PreAuthenticating.cs
+++ b/Exiled.Events/Patches/Events/Player/PreAuthenticating.cs
@@ -102,7 +102,7 @@ namespace Exiled.Events.Patches.Events.Player
 
                     // if (!ev.IsAllowed)
                     // {
-                    new(OpCodes.Callvirt, PropertyGetter(typeof(PreAuthenticatingEventArgs), nameof(PreAuthenticatingEventArgs.IsAllowed))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(PreAuthenticatingEventArgs), nameof(PreAuthenticatingEventArgs.AcceptConnection))),
                     new(OpCodes.Brtrue_S, elseLabel),
                     new(OpCodes.Ldloc, ev.LocalIndex),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(PreAuthenticatingEventArgs), nameof(PreAuthenticatingEventArgs.ServerFull))),


### PR DESCRIPTION
 - It's now possible to cancel preauth event when the server is full. Currently EXILED ignores `Reject` methods when the server is full, you have to manually uncancel the event first and then cancel it manually - and it still results in malformed packet being sent to the client (client received two rejection codes and ignored the second one - about server being full) and improper logging (EXILED doesn't print the message that a plugin rejected the preauth).
 - It's now not possible (again) to uncancel preauth event that is already canceled by a different plugin. Uncancelling a cancelled event preauth doesn't make the player not kicked and doesn't allow to change the kick reason. Additionally leaving a cancelled preauth event as uncancelled leads to further issues in the base game code.
 - Fixes `Delay` method - value is now properly checked and a proper exception is thrown.

Copy of https://github.com/Exiled-Team/EXILED/pull/1452, but for the EA repo.