### PR TITLE
Renaming ev.Player and ev.Target in IAttackerEvent events.

### DIFF
--- a/Exiled.CustomItems/API/EventArgs/OwnerDyingEventArgs.cs
+++ b/Exiled.CustomItems/API/EventArgs/OwnerDyingEventArgs.cs
@@ -26,11 +26,11 @@ namespace Exiled.CustomItems.API.EventArgs
         /// <param name="item"><inheritdoc cref="Item"/></param>
         /// <param name="ev">The <see cref="HandcuffingEventArgs"/> instance.</param>
         public OwnerDyingEventArgs(Item item, DyingEventArgs ev)
-            : base(ev.Target, ev.DamageHandler.Base)
+            : base(ev.Player, ev.DamageHandler.Base)
         {
             if (item is null)
                 Log.Warn("Item is null");
-            if (ev.Target is null)
+            if (ev.Player is null)
                 Log.Warn("Target is null");
             if (ev.DamageHandler.Base is null)
                 Log.Warn("handler base is null");

--- a/Exiled.CustomItems/API/EventArgs/UpgradingItemEventArgs.cs
+++ b/Exiled.CustomItems/API/EventArgs/UpgradingItemEventArgs.cs
@@ -30,12 +30,6 @@ namespace Exiled.CustomItems.API.EventArgs
         public UpgradingItemEventArgs(Player player, ItemBase item, Scp914KnobSetting knobSetting, bool isAllowed = true)
             : base(player, item, knobSetting, isAllowed)
         {
-            Item = item;
         }
-
-        /// <summary>
-        /// Gets the upgrading <see cref="Item"/> as a<see cref="CustomItem"/>.
-        /// </summary>
-        public new ItemBase Item { get; }
     }
 }

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -935,7 +935,7 @@ namespace Exiled.CustomItems.API.Features
 
         private void OnInternalOwnerDying(DyingEventArgs ev)
         {
-            foreach (Item item in ev.Target.Items.ToList())
+            foreach (Item item in ev.Player.Items.ToList())
             {
                 if (!Check(item))
                     continue;
@@ -945,13 +945,13 @@ namespace Exiled.CustomItems.API.Features
                 if (!ev.IsAllowed)
                     continue;
 
-                ev.Target.RemoveItem(item);
+                ev.Player.RemoveItem(item);
 
                 TrackedSerials.Remove(item.Serial);
 
-                Spawn(ev.Target, item, ev.Target);
+                Spawn(ev.Player, item, ev.Player);
 
-                MirrorExtensions.ResyncSyncVar(ev.Target.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
+                MirrorExtensions.ResyncSyncVar(ev.Player.ReferenceHub.networkIdentity, typeof(NicknameSync), nameof(NicknameSync.Network_myNickSync));
             }
         }
 

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -218,7 +218,7 @@ namespace Exiled.CustomItems.API.Features
         protected virtual void OnHurting(HurtingEventArgs ev)
         {
             if (ev.IsAllowed)
-                ev.Amount = ev.Target.Role == RoleTypeId.Scp106 ? Damage * 0.1f : Damage;
+                ev.Amount = ev.Player.Role == RoleTypeId.Scp106 ? Damage * 0.1f : Damage;
         }
 
         private void OnInternalReloading(ReloadingWeaponEventArgs ev)
@@ -287,24 +287,24 @@ namespace Exiled.CustomItems.API.Features
 
         private void OnInternalHurting(HurtingEventArgs ev)
         {
-            if (ev.Player is null)
+            if (ev.Attacker is null)
             {
                 return;
             }
 
-            if (ev.Target is null)
+            if (ev.Player is null)
             {
                 Log.Debug($"{Name}: {nameof(OnInternalHurting)}: target null", Instance.Config.Debug);
                 return;
             }
 
-            if (!Check(ev.Player.CurrentItem))
+            if (!Check(ev.Attacker.CurrentItem))
             {
                 Log.Debug($"{Name}: {nameof(OnInternalHurting)}: !Check()", Instance.Config.Debug);
                 return;
             }
 
-            if (ev.Player == ev.Target)
+            if (ev.Attacker == ev.Player)
             {
                 Log.Debug($"{Name}: {nameof(OnInternalHurting)}: attacker == target", Instance.Config.Debug);
                 return;
@@ -328,7 +328,7 @@ namespace Exiled.CustomItems.API.Features
                 return;
             }
 
-            if (!FriendlyFire && (ev.Player.Role.Team == ev.Target.Role.Team))
+            if (!FriendlyFire && (ev.Attacker.Role.Team == ev.Player.Role.Team))
             {
                 Log.Debug($"{Name}: {nameof(OnInternalHurting)}: FF is disabled for this weapon!", Instance.Config.Debug);
                 return;

--- a/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -748,10 +748,10 @@ namespace Exiled.CustomRoles.API.Features
 
         private void OnInternalDying(DyingEventArgs ev)
         {
-            if (Check(ev.Target))
+            if (Check(ev.Player))
             {
-                CustomRoles.Instance.StopRagdollPlayers.Add(ev.Target);
-                _ = new Ragdoll(new RagdollData(ev.Target.ReferenceHub, ev.DamageHandler, Role, ev.Target.Position, Quaternion.Euler(ev.Target.Rotation), ev.Target.DisplayNickname, NetworkTime.time), true);
+                CustomRoles.Instance.StopRagdollPlayers.Add(ev.Player);
+                _ = new Ragdoll(new RagdollData(ev.Player.ReferenceHub, ev.DamageHandler, Role, ev.Player.Position, Quaternion.Euler(ev.Player.Rotation), ev.Player.DisplayNickname, NetworkTime.time), true);
             }
         }
     }

--- a/Exiled.Events/EventArgs/Interfaces/IAttackerEvent.cs
+++ b/Exiled.Events/EventArgs/Interfaces/IAttackerEvent.cs
@@ -16,7 +16,7 @@ namespace Exiled.Events.EventArgs.Interfaces
     public interface IAttackerEvent : IPlayerEvent
     {
         /// <summary>
-        ///     Gets the <see cref="Player" /> being targeted.
+        ///     Gets the attacker <see cref="Player" />.
         /// </summary>
         public Player Attacker { get; }
 

--- a/Exiled.Events/EventArgs/Interfaces/IAttackerEvent.cs
+++ b/Exiled.Events/EventArgs/Interfaces/IAttackerEvent.cs
@@ -18,7 +18,7 @@ namespace Exiled.Events.EventArgs.Interfaces
         /// <summary>
         ///     Gets the <see cref="Player" /> being targeted.
         /// </summary>
-        public Player Target { get; }
+        public Player Attacker { get; }
 
         /// <summary>
         ///     Gets or sets the <see cref="DamageHandlerBase" /> managing the damage to the target.

--- a/Exiled.Events/EventArgs/Map/AnnouncingScpTerminationEventArgs.cs
+++ b/Exiled.Events/EventArgs/Map/AnnouncingScpTerminationEventArgs.cs
@@ -34,10 +34,10 @@ namespace Exiled.Events.EventArgs.Map
         /// </param>
         public AnnouncingScpTerminationEventArgs(Player scp, DamageHandlerBase damageHandlerBase, bool isAllowed = true)
         {
-            Target = scp;
+            Player = scp;
             Role = scp.Role;
             DamageHandler = new CustomDamageHandler(scp, damageHandlerBase);
-            Player = DamageHandler.BaseIs(out CustomAttackerHandler customAttackerHandler) ? customAttackerHandler.Attacker : null;
+            Attacker = DamageHandler.BaseIs(out CustomAttackerHandler customAttackerHandler) ? customAttackerHandler.Attacker : null;
             TerminationCause = damageHandlerBase.CassieDeathAnnouncement.Announcement;
             IsAllowed = isAllowed;
         }
@@ -55,12 +55,12 @@ namespace Exiled.Events.EventArgs.Map
         /// <summary>
         ///     Gets the player the announcement is being played for.
         /// </summary>
-        public Player Target { get; }
+        public Player Player { get; }
 
         /// <summary>
         ///     Gets the player who killed the SCP.
         /// </summary>
-        public Player Player { get; }
+        public Player Attacker { get; }
 
         /// <summary>
         ///     Gets or sets the <see cref="CustomDamageHandler" />.

--- a/Exiled.Events/EventArgs/Player/DiedEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DiedEventArgs.cs
@@ -33,8 +33,8 @@ namespace Exiled.Events.EventArgs.Player
         public DiedEventArgs(Player target, RoleTypeId targetOldRole, DamageHandlerBase damageHandler)
         {
             DamageHandler = new CustomDamageHandler(target, damageHandler);
-            Player = DamageHandler.BaseIs(out CustomAttackerHandler attackerDamageHandler) ? attackerDamageHandler.Attacker : null;
-            Target = target;
+            Attacker = DamageHandler.BaseIs(out CustomAttackerHandler attackerDamageHandler) ? attackerDamageHandler.Attacker : null;
+            Player = target;
             TargetOldRole = targetOldRole;
         }
 
@@ -46,7 +46,7 @@ namespace Exiled.Events.EventArgs.Player
         /// <summary>
         ///     Gets the killed player.
         /// </summary>
-        public Player Target { get; }
+        public Player Player { get; }
 
         /// <summary>
         ///     Gets or sets the <see cref="DamageHandler" />.
@@ -56,6 +56,6 @@ namespace Exiled.Events.EventArgs.Player
         /// <summary>
         ///     Gets the killer player.
         /// </summary>
-        public Player Player { get; }
+        public Player Attacker { get; }
     }
 }

--- a/Exiled.Events/EventArgs/Player/DyingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/DyingEventArgs.cs
@@ -36,8 +36,8 @@ namespace Exiled.Events.EventArgs.Player
         {
             DamageHandler = new CustomDamageHandler(target, damageHandler);
             ItemsToDrop = new List<Item>(target.Items.ToList());
-            Player = DamageHandler.BaseIs(out CustomAttackerHandler attackerDamageHandler) ? attackerDamageHandler.Attacker : null;
-            Target = target;
+            Attacker = DamageHandler.BaseIs(out CustomAttackerHandler attackerDamageHandler) ? attackerDamageHandler.Attacker : null;
+            Player = target;
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Exiled.Events.EventArgs.Player
         /// <summary>
         ///     Gets the dying player.
         /// </summary>
-        public Player Target { get; }
+        public Player Player { get; }
 
         /// <summary>
         ///     Gets or sets the <see cref="CustomDamageHandler" />.
@@ -63,6 +63,6 @@ namespace Exiled.Events.EventArgs.Player
         /// <summary>
         ///     Gets the killing player.
         /// </summary>
-        public Player Player { get; }
+        public Player Attacker { get; }
     }
 }

--- a/Exiled.Events/EventArgs/Player/HurtingEventArgs.cs
+++ b/Exiled.Events/EventArgs/Player/HurtingEventArgs.cs
@@ -17,13 +17,13 @@ namespace Exiled.Events.EventArgs.Player
     /// <summary>
     ///     Contains all information before a player gets damaged.
     /// </summary>
-    public class HurtingEventArgs : IPlayerEvent, IAttackerEvent, IDeniableEvent
+    public class HurtingEventArgs : IAttackerEvent, IDeniableEvent
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="HurtingEventArgs" /> class.
         /// </summary>
         /// <param name="target">
-        ///     <inheritdoc cref="Target" />
+        ///     <inheritdoc cref="Player" />
         /// </param>
         /// <param name="damageHandler">
         ///     <inheritdoc cref="DamageHandler" />
@@ -31,10 +31,10 @@ namespace Exiled.Events.EventArgs.Player
         public HurtingEventArgs(Player target, DamageHandlerBase damageHandler)
         {
             DamageHandler = new CustomDamageHandler(target, damageHandler);
-            Player = DamageHandler.BaseIs(out CustomAttackerHandler attackerDamageHandler)
+            Attacker = DamageHandler.BaseIs(out CustomAttackerHandler attackerDamageHandler)
                 ? attackerDamageHandler.Attacker
                 : null;
-            Target = target;
+            Player = target;
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace Exiled.Events.EventArgs.Player
         /// <summary>
         ///     Gets the target player, who is going to be hurt.
         /// </summary>
-        public Player Target { get; }
+        public Player Player { get; }
 
         /// <summary>
         ///     Gets or sets the <see cref="CustomDamageHandler" /> for the event.
@@ -64,6 +64,6 @@ namespace Exiled.Events.EventArgs.Player
         /// <summary>
         ///     Gets the attacker player.
         /// </summary>
-        public Player Player { get; }
+        public Player Attacker { get; }
     }
 }

--- a/Exiled.Events/Patches/Events/Map/AnnouncingScpTermination.cs
+++ b/Exiled.Events/Patches/Events/Map/AnnouncingScpTermination.cs
@@ -89,7 +89,7 @@ namespace Exiled.Events.Patches.Events.Map
                     // if (!ev.Player.IsSCP)
                     //     goto jmp;
                     new(OpCodes.Ldloc_S, ev.LocalIndex),
-                    new(OpCodes.Callvirt, PropertyGetter(typeof(AnnouncingScpTerminationEventArgs), nameof(AnnouncingScpTerminationEventArgs.Target))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(AnnouncingScpTerminationEventArgs), nameof(AnnouncingScpTerminationEventArgs.Player))),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.IsScp))),
                     new(OpCodes.Brfalse_S, jmp),
 

--- a/Exiled.Example/Events/PlayerHandler.cs
+++ b/Exiled.Example/Events/PlayerHandler.cs
@@ -34,7 +34,7 @@ namespace Exiled.Example.Events
             if (ev.Player is null)
                 return;
 
-            Log.Info($"{ev.Target.Nickname} ({ev.Target.Role}) died from {ev.Player.CurrentItem}! {ev.Player.Nickname} ({ev.Player.Role}) killed him!");
+            Log.Info($"{ev.Player.Nickname} ({ev.Player.Role}) died from {ev.DamageHandler.Type}! {ev.Attacker.Nickname} ({ev.Attacker.Role}) killed him!");
         }
 
         /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnChangingRole(ChangingRoleEventArgs)"/>
@@ -124,7 +124,7 @@ namespace Exiled.Example.Events
         /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnDying(DyingEventArgs)"/>
         public void OnDying(DyingEventArgs ev)
         {
-            Log.Info($"{ev.Target.Nickname} ({ev.Target.Role}) is getting killed by {ev.Player.Nickname} ({ev.Player.Role})!");
+            Log.Info($"{ev.Player.Nickname} ({ev.Player.Role}) is getting killed by {ev.Attacker.Nickname} ({ev.Attacker.Role})!");
         }
 
         /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnPreAuthenticating(PreAuthenticatingEventArgs)"/>
@@ -215,9 +215,9 @@ namespace Exiled.Example.Events
         /// <inheritdoc cref="Exiled.Events.Handlers.Player.OnHurting(HurtingEventArgs)"/>
         public void OnHurting(HurtingEventArgs ev)
         {
-            Log.Info($"{ev.Target} is being hurt by {ev.DamageHandler.Type}");
+            Log.Info($"{ev.Player} is being hurt by {ev.DamageHandler.Type}");
 
-            if (ev.Target.Role == RoleTypeId.Scientist)
+            if (ev.Player.Role == RoleTypeId.Scientist)
             {
                 Log.Info("Target is a nerd, setting damage to 1 because it's mean to bully nerds.");
                 ev.Amount = 1f;


### PR DESCRIPTION
- Fixed inconsistent naming in IAttackerEvent events. Instead of requiring the definition of the target, it now requires the definition of the attacker, since the events are triggered by things happening to the target. This means ev.Player (attacker) and ev.Target (target) are now ev.Attacker (attacker) and ev.Player (target)
                    NOTE: Since all of these events trigger off someone taking damage or dying etc, it makes more sense for consistency to have the person receiving said triggers be ev.Player, which it already is for all the other IPlayerEvent events. This will confuse a few people so best to get this change implemented super early.

- Removed unnecessary property replacement in CustomItems UpgradingItemEventArgs.

- Updated Example, CustomItems and CustomRoles logic to account for the above IAttackerEvent changes.