### PR TITLE
Fix SpawnReason

### DIFF
--- a/Exiled.API/Enums/SpawnReason.cs
+++ b/Exiled.API/Enums/SpawnReason.cs
@@ -53,7 +53,7 @@ namespace Exiled.API.Enums
         ForceClass,
 
         /// <summary>
-        /// The user will be destroy.
+        /// The user will be destroyed.
         /// </summary>
         Destroyed,
     }

--- a/Exiled.API/Enums/SpawnReason.cs
+++ b/Exiled.API/Enums/SpawnReason.cs
@@ -53,8 +53,8 @@ namespace Exiled.API.Enums
         ForceClass,
 
         /// <summary>
-        /// The user has entered Overwatch mode.
+        /// The user will be destroy.
         /// </summary>
-        Overwatch,
+        Destroyed,
     }
 }


### PR DESCRIPTION
- Overwatch now used ForceClass
- Destroyed it's call only when player left the server