### PR TITLE
Convert Exiled.Loader to NWAPI and add Debug to IConfig

### DIFF
--- a/Exiled.API/Features/Log.cs
+++ b/Exiled.API/Features/Log.cs
@@ -7,94 +7,130 @@
 
 namespace Exiled.API.Features
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
 
-    using Discord;
+    using Interfaces;
 
     /// <summary>
     /// A set of tools to print messages on the server console.
     /// </summary>
     public static class Log
     {
-        /// <summary>
-        /// Sends a <see cref="LogLevel.Info"/> level messages to the game console.
-        /// </summary>
-        /// <param name="message">The message to be sent.</param>
-        public static void Info(object message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", LogLevel.Info, System.ConsoleColor.Cyan);
+        private static Dictionary<Assembly, bool> knownDebugValues = new();
 
         /// <summary>
-        /// Sends a <see cref="LogLevel.Info"/> level messages to the game console.
+        /// Sends a <see cref="Discord.LogLevel.Info"/> level messages to the game console.
         /// </summary>
         /// <param name="message">The message to be sent.</param>
-        public static void Info(string message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", LogLevel.Info, System.ConsoleColor.Cyan);
+        public static void Info(object message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", Discord.LogLevel.Info, System.ConsoleColor.Cyan);
 
         /// <summary>
-        /// Sends a <see cref="LogLevel.Debug"/> level messages to the game console.
+        /// Sends a <see cref="Discord.LogLevel.Info"/> level messages to the game console.
+        /// </summary>
+        /// <param name="message">The message to be sent.</param>
+        public static void Info(string message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", Discord.LogLevel.Info, System.ConsoleColor.Cyan);
+
+        /// <summary>
+        /// Sends a <see cref="Discord.LogLevel.Debug"/> level messages to the game console.
         /// Server must have exiled_debug config enabled.
         /// </summary>
         /// <param name="message">The message to be sent.</param>
-        /// <param name="canBeSent">Indicates whether the log can be sent or not.</param>
-        public static void Debug(object message, bool canBeSent = true)
+        public static void Debug(object message)
         {
-            if (canBeSent)
-                Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", LogLevel.Debug, System.ConsoleColor.Green);
+#if !DEBUG
+            Assembly callingAssembly = Assembly.GetCallingAssembly();
+            if (!knownDebugValues.ContainsKey(callingAssembly))
+            {
+                if (!Server.PluginAssemblies.ContainsKey(callingAssembly))
+                    SetDebugThroughReflection(callingAssembly);
+                else
+                    knownDebugValues.Add(callingAssembly, Server.PluginAssemblies[callingAssembly].Config.Debug);
+            }
+
+            if (knownDebugValues[callingAssembly])
+#endif
+                Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", Discord.LogLevel.Debug, System.ConsoleColor.Green);
         }
 
         /// <summary>
-        /// Sends a <see cref="LogLevel.Debug"/> level messages to the game console.
+        /// Sends a <see cref="Discord.LogLevel.Debug"/> level messages to the game console.
         /// Server must have exiled_debug config enabled.
         /// </summary>
         /// <param name="message">The message to be sent.</param>
-        /// <param name="canBeSent">Indicates whether the log can be sent or not.</param>
-        public static void Debug(string message, bool canBeSent = true)
+        public static void Debug(string message)
         {
-            if (canBeSent)
-                Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", LogLevel.Debug, System.ConsoleColor.Green);
+#if !DEBUG
+            Assembly callingAssembly = Assembly.GetCallingAssembly();
+            if (!knownDebugValues.ContainsKey(callingAssembly))
+            {
+                if (!Server.PluginAssemblies.ContainsKey(callingAssembly))
+                    SetDebugThroughReflection(callingAssembly);
+                else
+                    knownDebugValues.Add(callingAssembly, Server.PluginAssemblies[callingAssembly].Config.Debug);
+            }
+
+            if (knownDebugValues[callingAssembly])
+#endif
+            Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", Discord.LogLevel.Debug, System.ConsoleColor.Green);
         }
 
         /// <summary>
-        /// Sends a <see cref="LogLevel.Debug"/> level messages to the game console.
+        /// Sends a <see cref="Discord.LogLevel.Debug"/> level messages to the game console.
         /// Server must have exiled_debug config enabled.
         /// </summary>
         /// <typeparam name="T">The inputted object's type.</typeparam>
         /// <param name="object">The object to be logged and returned.</param>
-        /// <param name="canBeSent">Indicates whether the log can be sent or not.</param>
         /// <returns>Returns the <typeparamref name="T"/> object inputted in <paramref name="object"/>.</returns>
-        public static T DebugObject<T>(T @object, bool canBeSent = true)
+        public static T DebugObject<T>(T @object)
         {
-            if (canBeSent)
-                Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {@object}", LogLevel.Debug, System.ConsoleColor.Green);
+#if !DEBUG
+            Assembly callingAssembly = Assembly.GetCallingAssembly();
+            if (!knownDebugValues.ContainsKey(callingAssembly))
+            {
+                if (!Server.PluginAssemblies.ContainsKey(callingAssembly))
+                    SetDebugThroughReflection(callingAssembly);
+                else
+                    knownDebugValues.Add(callingAssembly, Server.PluginAssemblies[callingAssembly].Config.Debug);
+            }
 
+            if (knownDebugValues[callingAssembly])
+#endif
+                Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {@object}", Discord.LogLevel.Debug, System.ConsoleColor.Green);
+#pragma warning disable SA1137
             return @object;
+#pragma warning restore SA1137
         }
 
         /// <summary>
-        /// Sends a <see cref="LogLevel.Warn"/> level messages to the game console.
+        /// Sends a <see cref="Discord.LogLevel.Warn"/> level messages to the game console.
         /// </summary>
         /// <param name="message">The message to be sent.</param>
-        public static void Warn(object message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", LogLevel.Warn, System.ConsoleColor.Magenta);
+        public static void Warn(object message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", Discord.LogLevel.Warn, System.ConsoleColor.Magenta);
 
         /// <summary>
-        /// Sends a <see cref="LogLevel.Warn"/> level messages to the game console.
+        /// Sends a <see cref="Discord.LogLevel.Warn"/> level messages to the game console.
         /// </summary>
         /// <param name="message">The message to be sent.</param>
-        public static void Warn(string message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", LogLevel.Warn, System.ConsoleColor.Magenta);
+        public static void Warn(string message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", Discord.LogLevel.Warn, System.ConsoleColor.Magenta);
 
         /// <summary>
-        /// Sends a <see cref="LogLevel.Error"/> level messages to the game console.
+        /// Sends a <see cref="Discord.LogLevel.Error"/> level messages to the game console.
         /// This should be used to send errors only.
         /// It's recommended to send any messages in the catch block of a try/catch as errors with the exception string.
         /// </summary>
         /// <param name="message">The message to be sent.</param>
-        public static void Error(object message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", LogLevel.Error, System.ConsoleColor.DarkRed);
+        public static void Error(object message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", Discord.LogLevel.Error, System.ConsoleColor.DarkRed);
 
         /// <summary>
-        /// Sends a <see cref="LogLevel.Error"/> level messages to the game console.
+        /// Sends a <see cref="Discord.LogLevel.Error"/> level messages to the game console.
         /// This should be used to send errors only.
         /// It's recommended to send any messages in the catch block of a try/catch as errors with the exception string.
         /// </summary>
         /// <param name="message">The message to be sent.</param>
-        public static void Error(string message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", LogLevel.Error, System.ConsoleColor.DarkRed);
+        public static void Error(string message) => Send($"[{Assembly.GetCallingAssembly().GetName().Name}] {message}", Discord.LogLevel.Error, System.ConsoleColor.DarkRed);
 
         /// <summary>
         /// Sends a log message to the game console.
@@ -102,7 +138,7 @@ namespace Exiled.API.Features
         /// <param name="message">The message to be sent.</param>
         /// <param name="level">The message level of importance.</param>
         /// <param name="color">The message color.</param>
-        public static void Send(object message, LogLevel level, System.ConsoleColor color = System.ConsoleColor.Gray)
+        public static void Send(object message, Discord.LogLevel level, System.ConsoleColor color = System.ConsoleColor.Gray)
         {
             SendRaw($"[{level.ToString().ToUpper()}] {message}", color);
         }
@@ -113,7 +149,7 @@ namespace Exiled.API.Features
         /// <param name="message">The message to be sent.</param>
         /// <param name="level">The message level of importance.</param>
         /// <param name="color">The message color.</param>
-        public static void Send(string message, LogLevel level, System.ConsoleColor color = System.ConsoleColor.Gray)
+        public static void Send(string message, Discord.LogLevel level, System.ConsoleColor color = System.ConsoleColor.Gray)
         {
             SendRaw($"[{level.ToString().ToUpper()}] {message}", color);
         }
@@ -152,7 +188,21 @@ namespace Exiled.API.Features
 
             Error(message);
 
-            throw new System.Exception(message.ToString());
+            throw new Exception(message.ToString());
+        }
+
+        private static void SetDebugThroughReflection(Assembly assembly)
+        {
+            try
+            {
+                IPlugin<IConfig> eventsPlugin = Server.PluginAssemblies.Values.FirstOrDefault(p => p.Name == "Exiled.Events");
+                knownDebugValues.Add(assembly, eventsPlugin?.Config.Debug ?? false);
+            }
+            catch (Exception e)
+            {
+                Error(e);
+                knownDebugValues.Add(assembly, false);
+            }
         }
     }
 }

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -475,18 +475,18 @@ namespace Exiled.API.Features
         /// <para>
         /// The type of the Role is different based on the <see cref="RoleTypeId"/> of the player, and casting should be used to modify the role.
         /// <br /><see cref="RoleTypeId.Spectator"/> = <see cref="SpectatorRole"/>.
-        /// <br /><see cref="RoleTypeId.None"/> = <see cref="NoneRole"/>.
+        /// <br /><see cref="RoleTypeId.None"/> = <see cref="Roles.NoneRole"/>.
         /// <br /><see cref="RoleTypeId.Scp049"/> = <see cref="Scp049Role"/>.
         /// <br /><see cref="RoleTypeId.Scp0492"/> = <see cref="Scp0492Role"/>.
-        /// <br /><see cref="RoleTypeId.Scp079"/> = <see cref="Scp079Role"/>.
+        /// <br /><see cref="RoleTypeId.Scp079"/> = <see cref="Roles.Scp079Role"/>.
         /// <br /><see cref="RoleTypeId.Scp096"/> = <see cref="Scp096Role"/>.
-        /// <br /><see cref="RoleTypeId.Scp106"/> = <see cref="Scp106Role"/>.
-        /// <br /><see cref="RoleTypeId.Scp173"/> = <see cref="Scp173Role"/>.
-        /// <br /><see cref="RoleTypeId.Scp939"/> = <see cref="Scp939Role"/>.
+        /// <br /><see cref="RoleTypeId.Scp106"/> = <see cref="Roles.Scp106Role"/>.
+        /// <br /><see cref="RoleTypeId.Scp173"/> = <see cref="Roles.Scp173Role"/>.
+        /// <br /><see cref="RoleTypeId.Scp939"/> = <see cref="Roles.Scp939Role"/>.
         /// <br />If not listed above, the type of Role will be <see cref="HumanRole"/>.
         /// </para>
         /// <para>
-        /// If the role object is stored, it may become invalid if the player changes roles. Thus, the <see cref="Role.IsValid"/> property can be checked. If this property is <see langword="false"/>, the role should be discarded and this property should be used again to get the new Role.
+        /// If the role object is stored, it may become invalid if the player changes roles. Thus, the <see cref="Roles.Role.IsValid"/> property can be checked. If this property is <see langword="false"/>, the role should be discarded and this property should be used again to get the new Role.
         /// This role is automatically cached until it changes, and it is recommended to use this propertly directly rather than storing the property yourself.
         /// </para>
         /// <para>
@@ -1068,7 +1068,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets the <see cref="Player"/> belonging to a specific netId, if any.
         /// </summary>
-        /// <param name="netId">The player's <see cref="NetworkIdentity.netId"/>.</param>
+        /// <param name="netId">The player's <see cref="Mirror.NetworkIdentity.netId"/>.</param>
         /// <returns>The <see cref="Player"/> owning the netId, or <see langword="null"/> if not found.</returns>
         public static Player Get(uint netId) => ReferenceHub.TryGetHubNetID(netId, out ReferenceHub hub) ? Get(hub) : null;
 
@@ -1966,10 +1966,10 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets the maximum amount of ammo the player can hold, given the ammo <see cref="AmmoType"/>.
         /// This method factors in the armor the player is wearing, as well as server configuration.
-        /// For the maximum amount of ammo that can be given regardless of worn armor and server configuration, see <see cref="Ammo.AmmoLimit"/>.
+        /// For the maximum amount of ammo that can be given regardless of worn armor and server configuration, see <see cref="Features.Items.Ammo.AmmoLimit"/>.
         /// </summary>
         /// <param name="type">The <see cref="AmmoType"/> of the ammo to check.</param>
-        /// <returns>The maximum amount of ammo this player can carry. Guaranteed to be between <c>0</c> and <see cref="Ammo.AmmoLimit"/>.</returns>
+        /// <returns>The maximum amount of ammo this player can carry. Guaranteed to be between <c>0</c> and <see cref="Features.Items.Ammo.AmmoLimit"/>.</returns>
         public int GetAmmoLimit(AmmoType type) =>
             InventorySystem.Configs.InventoryLimits.GetAmmoLimit(type.GetItemType(), referenceHub);
 

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -13,12 +13,11 @@ namespace Exiled.API.Features
 
     using CustomPlayerEffects;
     using GameCore;
+    using Interfaces;
     using MEC;
-
     using Mirror;
     using PlayerRoles.RoleAssign;
     using RoundRestarting;
-
     using UnityEngine;
 
     /// <summary>
@@ -27,6 +26,11 @@ namespace Exiled.API.Features
     public static class Server
     {
         private static MethodInfo sendSpawnMessage;
+
+        /// <summary>
+        /// Gets a dictionary that pairs assemblies with their associated plugins.
+        /// </summary>
+        public static Dictionary<Assembly, IPlugin<IConfig>> PluginAssemblies { get; } = new();
 
         /// <summary>
         /// Gets the player's host of the server.

--- a/Exiled.API/Interfaces/IConfig.cs
+++ b/Exiled.API/Interfaces/IConfig.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Interfaces
 {
+    using System.ComponentModel;
+
     /// <summary>
     /// Defines the contract for basic config features.
     /// </summary>
@@ -15,6 +17,13 @@ namespace Exiled.API.Interfaces
         /// <summary>
         /// Gets or sets a value indicating whether the plugin is enabled or not.
         /// </summary>
+        [Description("Whether or not this plugin is enabled.")]
         bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether debug messages should be displayed in the console or not.
+        /// </summary>
+        [Description("Whether or not debug messages should be shown in the console.")]
+        bool Debug { get; set; }
     }
 }

--- a/Exiled.CreditTags/Config.cs
+++ b/Exiled.CreditTags/Config.cs
@@ -16,8 +16,10 @@ namespace Exiled.CreditTags
     public sealed class Config : IConfig
     {
         /// <inheritdoc/>
-        [Description("Is the plugin enabled?")]
         public bool IsEnabled { get; set; } = true;
+
+        /// <inheritdoc/>
+        public bool Debug { get; set; }
 
         [Description("Info side - Badge, CustomPlayerInfo, FirstAvailable")]
         public InfoSide Mode { get; private set; } = InfoSide.FirstAvailable;

--- a/Exiled.CreditTags/CreditTags.cs
+++ b/Exiled.CreditTags/CreditTags.cs
@@ -110,13 +110,13 @@ namespace Exiled.CreditTags
                 }
                 else
                 {
-                    Log.Debug($"{nameof(SuccessHandler)}: Invalid RankKind - response: {result}", Loader.Loader.ShouldDebugBeShown);
+                    Log.Debug($"{nameof(SuccessHandler)}: Invalid RankKind - response: {result}");
                 }
             }
 
             void ErrorHandler(ThreadSafeRequest request)
             {
-                Log.Debug($"{nameof(ErrorHandler)}: Response: {request.Result} Code: {request.Code}", Loader.Loader.ShouldDebugBeShown);
+                Log.Debug($"{nameof(ErrorHandler)}: Response: {request.Result} Code: {request.Code}");
 
                 errorHandler?.Invoke();
             }

--- a/Exiled.CustomItems/API/Extensions.cs
+++ b/Exiled.CustomItems/API/Extensions.cs
@@ -43,7 +43,7 @@ namespace Exiled.CustomItems.API
                 }
                 else if (!CustomItem.TryGive(player, item, displayMessage))
                 {
-                    Log.Debug($"\"{item}\" is not a valid item name, nor a custom item name.", CustomItems.Instance.Config.Debug);
+                    Log.Debug($"\"{item}\" is not a valid item name, nor a custom item name.");
                 }
             }
         }

--- a/Exiled.CustomItems/API/Features/CustomGrenade.cs
+++ b/Exiled.CustomItems/API/Features/CustomGrenade.cs
@@ -196,7 +196,7 @@ namespace Exiled.CustomItems.API.Features
             if (!Check(ev.Player.CurrentItem))
                 return;
 
-            Log.Debug($"{ev.Player.Nickname} has thrown a {Name}!", CustomItems.Instance.Config.Debug);
+            Log.Debug($"{ev.Player.Nickname} has thrown a {Name}!");
 
             OnThrowing(ev);
 
@@ -218,7 +218,7 @@ namespace Exiled.CustomItems.API.Features
         {
             if (Check(ev.Grenade))
             {
-                Log.Debug($"A {Name} is exploding!!", CustomItems.Instance.Config.Debug);
+                Log.Debug($"A {Name} is exploding!!");
                 OnExploding(ev);
             }
         }

--- a/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -309,9 +309,9 @@ namespace Exiled.CustomItems.API.Features
                     CustomItem customItem = null;
                     bool flag = false;
 
-                    if (!skipReflection && Loader.PluginAssemblies.ContainsKey(assembly))
+                    if (!skipReflection && Server.PluginAssemblies.ContainsKey(assembly))
                     {
-                        IPlugin<IConfig> plugin = Loader.PluginAssemblies[assembly];
+                        IPlugin<IConfig> plugin = Server.PluginAssemblies[assembly];
                         foreach (PropertyInfo property in overrideClass?.GetType().GetProperties() ?? plugin.Config.GetType().GetProperties())
                         {
                             if (property.PropertyType != type)
@@ -388,9 +388,9 @@ namespace Exiled.CustomItems.API.Features
                 {
                     CustomItem customItem = null;
 
-                    if (!skipReflection && Loader.PluginAssemblies.ContainsKey(assembly))
+                    if (!skipReflection && Server.PluginAssemblies.ContainsKey(assembly))
                     {
-                        IPlugin<IConfig> plugin = Loader.PluginAssemblies[assembly];
+                        IPlugin<IConfig> plugin = Server.PluginAssemblies[assembly];
 
                         foreach (PropertyInfo property in overrideClass?.GetType().GetProperties() ?? plugin.Config.GetType().GetProperties())
                         {
@@ -539,7 +539,7 @@ namespace Exiled.CustomItems.API.Features
 
             foreach (SpawnPoint spawnPoint in spawnPoints)
             {
-                Log.Debug($"Attempting to spawn {Name} at {spawnPoint.Position}.", Instance.Config.Debug);
+                Log.Debug($"Attempting to spawn {Name} at {spawnPoint.Position}.");
 
                 if (UnityEngine.Random.Range(1, 101) >= spawnPoint.Chance || ((limit > 0) && (spawned >= limit)))
                     continue;
@@ -552,7 +552,7 @@ namespace Exiled.CustomItems.API.Features
                     {
                         if (Map.Lockers is null)
                         {
-                            Log.Debug($"{nameof(Spawn)}: Locker list is null.", Instance.Config.Debug);
+                            Log.Debug($"{nameof(Spawn)}: Locker list is null.");
                             continue;
                         }
 
@@ -562,19 +562,19 @@ namespace Exiled.CustomItems.API.Features
 
                         if (locker is null)
                         {
-                            Log.Debug($"{nameof(Spawn)}: Selected locker is null.", Instance.Config.Debug);
+                            Log.Debug($"{nameof(Spawn)}: Selected locker is null.");
                             continue;
                         }
 
                         if (locker.Loot is null)
                         {
-                            Log.Debug($"{nameof(Spawn)}: Invalid locker location. Attempting to find a new one..", Instance.Config.Debug);
+                            Log.Debug($"{nameof(Spawn)}: Invalid locker location. Attempting to find a new one..");
                             continue;
                         }
 
                         if (locker.Chambers is null)
                         {
-                            Log.Debug($"{nameof(Spawn)}: Locker chambers is null", Instance.Config.Debug);
+                            Log.Debug($"{nameof(Spawn)}: Locker chambers is null");
                             continue;
                         }
 
@@ -582,13 +582,13 @@ namespace Exiled.CustomItems.API.Features
 
                         if (chamber is null)
                         {
-                            Log.Debug($"{nameof(Spawn)}: chamber is null", Instance.Config.Debug);
+                            Log.Debug($"{nameof(Spawn)}: chamber is null");
                             continue;
                         }
 
                         Vector3 position = chamber._spawnpoint.transform.position;
                         Spawn(position, (Player)null);
-                        Log.Debug($"Spawned {Name} at {position} ({spawnPoint.Name})", Instance.Config.Debug);
+                        Log.Debug($"Spawned {Name} at {position} ({spawnPoint.Name})");
 
                         break;
                     }
@@ -607,7 +607,7 @@ namespace Exiled.CustomItems.API.Features
                         firearmPickup.NetworkStatus = firearmPickup.Status;
                     }
 
-                    Log.Debug($"Spawned {Name} at {spawnPoint.Position} ({spawnPoint.Name})", Instance.Config.Debug);
+                    Log.Debug($"Spawned {Name} at {spawnPoint.Position} ({spawnPoint.Name})");
                 }
             }
 
@@ -645,11 +645,11 @@ namespace Exiled.CustomItems.API.Features
         {
             try
             {
-                Log.Debug($"{Name}.{nameof(Give)}: Item Serial: {item.Serial} Ammo: {(item is Firearm firearm ? firearm.Ammo : -1)}", Instance.Config.Debug);
+                Log.Debug($"{Name}.{nameof(Give)}: Item Serial: {item.Serial} Ammo: {(item is Firearm firearm ? firearm.Ammo : -1)}");
 
                 player.AddItem(item);
 
-                Log.Debug($"{nameof(Give)}: Adding {item.Serial} to tracker.", Instance.Config.Debug);
+                Log.Debug($"{nameof(Give)}: Adding {item.Serial} to tracker.");
                 if (!TrackedSerials.Contains(item.Serial))
                     TrackedSerials.Add(item.Serial);
 
@@ -722,10 +722,10 @@ namespace Exiled.CustomItems.API.Features
             if (!Instance.Config.IsEnabled)
                 return false;
 
-            Log.Debug($"Trying to register {Name} ({Id}).", Instance.Config.Debug);
+            Log.Debug($"Trying to register {Name} ({Id}).");
             if (!Registered.Contains(this))
             {
-                Log.Debug("Registered items doesn't contain this item yet..", Instance.Config.Debug);
+                Log.Debug("Registered items doesn't contain this item yet..");
                 if (Registered.Any(customItem => customItem.Id == Id))
                 {
                     Log.Warn($"{Name} has tried to register with the same custom item ID as another item: {Id}. It will not be registered.");
@@ -733,12 +733,12 @@ namespace Exiled.CustomItems.API.Features
                     return false;
                 }
 
-                Log.Debug("Adding item to registered list..", Instance.Config.Debug);
+                Log.Debug("Adding item to registered list..");
                 Registered.Add(this);
 
                 Init();
 
-                Log.Debug($"{Name} ({Id}) [{Type}] has been successfully registered.", Instance.Config.Debug);
+                Log.Debug($"{Name} ({Id}) [{Type}] has been successfully registered.");
 
                 return true;
             }

--- a/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -75,7 +75,7 @@ namespace Exiled.CustomItems.API.Features
 
             if (item is null)
             {
-                Log.Debug($"{nameof(Spawn)}: Item is null.", Instance.Config.Debug);
+                Log.Debug($"{nameof(Spawn)}: Item is null.");
                 return null;
             }
 
@@ -85,7 +85,7 @@ namespace Exiled.CustomItems.API.Features
             Pickup pickup = item.Spawn(position);
             if (pickup is null)
             {
-                Log.Debug($"{nameof(Spawn)}: Pickup is null.", Instance.Config.Debug);
+                Log.Debug($"{nameof(Spawn)}: Pickup is null.");
                 return null;
             }
 
@@ -104,7 +104,7 @@ namespace Exiled.CustomItems.API.Features
                     {
                         firearmPickup.Status = new FirearmStatus(ClipSize, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
                         firearmPickup.NetworkStatus = firearmPickup.Status;
-                        Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawned item has: {firearmPickup.Status.Ammo}", Instance.Config.Debug);
+                        Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawned item has: {firearmPickup.Status.Ammo}");
                     }
                 });
 
@@ -119,7 +119,7 @@ namespace Exiled.CustomItems.API.Features
                 if (!Attachments.IsEmpty())
                     firearm.AddAttachment(Attachments);
                 byte ammo = firearm.Ammo;
-                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ammo} ammo.", Instance.Config.Debug);
+                Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawning weapon with {ammo} ammo.");
                 Pickup pickup = firearm.Spawn(position);
                 pickup.Scale = Scale;
 
@@ -136,7 +136,7 @@ namespace Exiled.CustomItems.API.Features
                         {
                             firearmPickup.Status = new FirearmStatus(ammo, firearmPickup.Status.Flags, firearmPickup.Status.Attachments);
                             firearmPickup.NetworkStatus = firearmPickup.Status;
-                            Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawned item has: {firearmPickup.Status.Ammo}", Instance.Config.Debug);
+                            Log.Debug($"{nameof(Name)}.{nameof(Spawn)}: Spawned item has: {firearmPickup.Status.Ammo}");
                         }
                     });
 
@@ -158,7 +158,7 @@ namespace Exiled.CustomItems.API.Features
                 firearm.Ammo = ClipSize;
             }
 
-            Log.Debug($"{nameof(Give)}: Adding {item.Serial} to tracker.", Instance.Config.Debug);
+            Log.Debug($"{nameof(Give)}: Adding {item.Serial} to tracker.");
             TrackedSerials.Add(item.Serial);
 
             if (displayMessage)
@@ -226,17 +226,17 @@ namespace Exiled.CustomItems.API.Features
             if (!Check(ev.Firearm))
                 return;
 
-            Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: Reloading weapon. Calling external reload event..", Instance.Config.Debug);
+            Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: Reloading weapon. Calling external reload event..");
             OnReloading(ev);
 
-            Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: External event ended. {ev.IsAllowed}", Instance.Config.Debug);
+            Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: External event ended. {ev.IsAllowed}");
             if (!ev.IsAllowed)
             {
-                Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: External event turned is allowed to false, returning.", Instance.Config.Debug);
+                Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: External event turned is allowed to false, returning.");
                 return;
             }
 
-            Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: Continuing with internal reload..", Instance.Config.Debug);
+            Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: Continuing with internal reload..");
             ev.IsAllowed = false;
 
             byte remainingClip = ((Firearm)ev.Player.CurrentItem).Ammo;
@@ -244,13 +244,13 @@ namespace Exiled.CustomItems.API.Features
             if (remainingClip >= ClipSize)
                 return;
 
-            Log.Debug($"{ev.Player.Nickname} ({ev.Player.UserId}) [{ev.Player.Role}] is reloading a {Name} ({Id}) [{Type} ({remainingClip}/{ClipSize})]!", Instance.Config.Debug);
+            Log.Debug($"{ev.Player.Nickname} ({ev.Player.UserId}) [{ev.Player.Role}] is reloading a {Name} ({Id}) [{Type} ({remainingClip}/{ClipSize})]!");
 
             AmmoType ammoType = ((Firearm)ev.Player.CurrentItem).AmmoType;
 
             if (!ev.Player.Ammo.ContainsKey(ammoType.GetItemType()))
             {
-                Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: {ev.Player.Nickname} does not have ammo to reload this weapon.", Instance.Config.Debug);
+                Log.Debug($"{nameof(Name)}.{nameof(OnInternalReloading)}: {ev.Player.Nickname} does not have ammo to reload this weapon.");
                 return;
             }
 
@@ -266,7 +266,7 @@ namespace Exiled.CustomItems.API.Features
             ev.Player.Ammo[ammoType.GetItemType()] -= amountToReload;
             ((Firearm)ev.Player.CurrentItem).Ammo = (byte)(((Firearm)ev.Player.CurrentItem).Ammo + amountToReload);
 
-            Log.Debug($"{ev.Player.Nickname} ({ev.Player.UserId}) [{ev.Player.Role}] reloaded a {Name} ({Id}) [{Type} ({((Firearm)ev.Player.CurrentItem).Ammo}/{ClipSize})]!", Instance.Config.Debug);
+            Log.Debug($"{ev.Player.Nickname} ({ev.Player.UserId}) [{ev.Player.Role}] reloaded a {Name} ({Id}) [{Type} ({((Firearm)ev.Player.CurrentItem).Ammo}/{ClipSize})]!");
         }
 
         private void OnInternalShooting(ShootingEventArgs ev)
@@ -294,43 +294,43 @@ namespace Exiled.CustomItems.API.Features
 
             if (ev.Player is null)
             {
-                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: target null", Instance.Config.Debug);
+                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: target null");
                 return;
             }
 
             if (!Check(ev.Attacker.CurrentItem))
             {
-                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: !Check()", Instance.Config.Debug);
+                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: !Check()");
                 return;
             }
 
             if (ev.Attacker == ev.Player)
             {
-                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: attacker == target", Instance.Config.Debug);
+                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: attacker == target");
                 return;
             }
 
             if (ev.DamageHandler is null)
             {
-                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: Handler null", Instance.Config.Debug);
+                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: Handler null");
                 return;
             }
 
             if (!ev.DamageHandler.CustomBase.BaseIs(out FirearmDamageHandler firearmDamageHandler))
             {
-                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: Handler not firearm", Instance.Config.Debug);
+                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: Handler not firearm");
                 return;
             }
 
             if (!Check(firearmDamageHandler.Item))
             {
-                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: type != type", Instance.Config.Debug);
+                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: type != type");
                 return;
             }
 
             if (!FriendlyFire && (ev.Attacker.Role.Team == ev.Player.Role.Team))
             {
-                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: FF is disabled for this weapon!", Instance.Config.Debug);
+                Log.Debug($"{Name}: {nameof(OnInternalHurting)}: FF is disabled for this weapon!");
                 return;
             }
 

--- a/Exiled.CustomItems/Config.cs
+++ b/Exiled.CustomItems/Config.cs
@@ -22,6 +22,9 @@ namespace Exiled.CustomItems
         [Description("Indicates whether this plugin is enabled or not.")]
         public bool IsEnabled { get; set; } = true;
 
+        /// <inheritdoc/>
+        public bool Debug { get; set; } = false;
+
         /// <summary>
         /// Gets the hint that is shown when someone pickups a <see cref="CustomItem"/>.
         /// </summary>
@@ -33,11 +36,5 @@ namespace Exiled.CustomItems
         /// </summary>
         [Description("The hint that is shown when someone selects a custom item.")]
         public Broadcast SelectedHint { get; private set; } = new("You have selected a {0}\n{1}", 5);
-
-        /// <summary>
-        /// Gets a value indicating whether if debug mode is enabled.
-        /// </summary>
-        [Description("Whether or not debug messages should be displayed in the server console.")]
-        public bool Debug { get; private set; } = false;
     }
 }

--- a/Exiled.CustomRoles/API/Features/CustomAbility.cs
+++ b/Exiled.CustomRoles/API/Features/CustomAbility.cs
@@ -101,9 +101,9 @@ namespace Exiled.CustomRoles.API.Features
 
                 CustomAbility customAbility = null;
 
-                if (!skipReflection && Loader.PluginAssemblies.ContainsKey(assembly))
+                if (!skipReflection && Server.PluginAssemblies.ContainsKey(assembly))
                 {
-                    IPlugin<IConfig> plugin = Loader.PluginAssemblies[assembly];
+                    IPlugin<IConfig> plugin = Server.PluginAssemblies[assembly];
 
                     foreach (PropertyInfo property in overrideClass?.GetType().GetProperties() ??
                                                       plugin.Config.GetType().GetProperties())
@@ -146,9 +146,9 @@ namespace Exiled.CustomRoles.API.Features
 
                 CustomAbility customAbility = null;
 
-                if (!skipReflection && Loader.PluginAssemblies.ContainsKey(assembly))
+                if (!skipReflection && Server.PluginAssemblies.ContainsKey(assembly))
                 {
-                    IPlugin<IConfig> plugin = Loader.PluginAssemblies[assembly];
+                    IPlugin<IConfig> plugin = Server.PluginAssemblies[assembly];
 
                     foreach (PropertyInfo property in overrideClass?.GetType().GetProperties() ?? plugin.Config.GetType().GetProperties())
                     {
@@ -267,7 +267,7 @@ namespace Exiled.CustomRoles.API.Features
                 Registered.Add(this);
                 Init();
 
-                Log.Debug($"{Name} has been successfully registered.", CustomRoles.Instance.Config.Debug);
+                Log.Debug($"{Name} has been successfully registered.");
 
                 return true;
             }

--- a/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -180,9 +180,9 @@ namespace Exiled.CustomRoles.API.Features
                 {
                     CustomRole customRole = null;
 
-                    if (!skipReflection && Loader.PluginAssemblies.ContainsKey(assembly))
+                    if (!skipReflection && Server.PluginAssemblies.ContainsKey(assembly))
                     {
-                        IPlugin<IConfig> plugin = Loader.PluginAssemblies[assembly];
+                        IPlugin<IConfig> plugin = Server.PluginAssemblies[assembly];
 
                         foreach (PropertyInfo property in overrideClass?.GetType().GetProperties() ?? plugin.Config.GetType().GetProperties())
                         {
@@ -234,9 +234,9 @@ namespace Exiled.CustomRoles.API.Features
                 {
                     CustomRole customRole = null;
 
-                    if (!skipReflection && Loader.PluginAssemblies.ContainsKey(assembly))
+                    if (!skipReflection && Server.PluginAssemblies.ContainsKey(assembly))
                     {
-                        IPlugin<IConfig> plugin = Loader.PluginAssemblies[assembly];
+                        IPlugin<IConfig> plugin = Server.PluginAssemblies[assembly];
 
                         foreach (PropertyInfo property in overrideClass?.GetType().GetProperties() ??
                                                           plugin.Config.GetType().GetProperties())
@@ -400,7 +400,7 @@ namespace Exiled.CustomRoles.API.Features
         {
             Vector3 oldPos = player.Position;
 
-            Log.Debug($"{Name}: Adding role to {player.Nickname}.", CustomRoles.Instance.Config.Debug);
+            Log.Debug($"{Name}: Adding role to {player.Nickname}.");
 
             if (Role != RoleTypeId.None)
                 player.SetRole(Role, SpawnReason.ForceClass);
@@ -411,41 +411,41 @@ namespace Exiled.CustomRoles.API.Features
                 {
                     Vector3 pos = GetSpawnPosition();
 
-                    Log.Debug($"{nameof(AddRole)}: Found {pos} to spawn {player.Nickname}", CustomRoles.Instance.Config.Debug);
+                    Log.Debug($"{nameof(AddRole)}: Found {pos} to spawn {player.Nickname}");
 
                     // If the spawn pos isn't 0,0,0, We add vector3.up * 1.5 here to ensure they do not spawn inside the ground and get stuck.
                     player.Position = oldPos;
                     if (pos != Vector3.zero)
                     {
-                        Log.Debug($"{nameof(AddRole)}: Setting {player.Nickname} position..", CustomRoles.Instance.Config.Debug);
+                        Log.Debug($"{nameof(AddRole)}: Setting {player.Nickname} position..");
                         player.Position = pos + (Vector3.up * 1.5f);
                     }
 
                     if (!KeepInventoryOnSpawn)
                     {
-                        Log.Debug($"{Name}: Clearing {player.Nickname}'s inventory.", CustomRoles.Instance.Config.Debug);
+                        Log.Debug($"{Name}: Clearing {player.Nickname}'s inventory.");
                         player.ClearInventory();
                     }
 
                     foreach (string itemName in Inventory)
                     {
-                        Log.Debug($"{Name}: Adding {itemName} to inventory.", CustomRoles.Instance.Config.Debug);
+                        Log.Debug($"{Name}: Adding {itemName} to inventory.");
                         TryAddItem(player, itemName);
                     }
 
                     foreach (AmmoType ammo in Ammo.Keys)
                     {
-                        Log.Debug($"{Name}: Adding {Ammo[ammo]} {ammo} to inventory.", CustomRoles.Instance.Config.Debug);
+                        Log.Debug($"{Name}: Adding {Ammo[ammo]} {ammo} to inventory.");
                         player.SetAmmo(ammo, Ammo[ammo]);
                     }
 
-                    Log.Debug($"{Name}: Setting health values.", CustomRoles.Instance.Config.Debug);
+                    Log.Debug($"{Name}: Setting health values.");
                     player.Health = MaxHealth;
                     player.MaxHealth = MaxHealth;
                     player.Scale = Scale;
                 });
 
-            Log.Debug($"{Name}: Setting player info", CustomRoles.Instance.Config.Debug);
+            Log.Debug($"{Name}: Setting player info");
             player.CustomInfo = CustomInfo;
             player.InfoArea &= ~PlayerInfoArea.Role;
             if (CustomAbilities is not null)
@@ -467,7 +467,7 @@ namespace Exiled.CustomRoles.API.Features
         /// <param name="player">The <see cref="Player"/> to remove the role from.</param>
         public virtual void RemoveRole(Player player)
         {
-            Log.Debug($"{Name}: Removing role from {player.Nickname}", CustomRoles.Instance.Config.Debug);
+            Log.Debug($"{Name}: Removing role from {player.Nickname}");
             TrackedPlayers.Remove(player);
             player.CustomInfo = string.Empty;
             player.InfoArea |= PlayerInfoArea.Role;
@@ -595,7 +595,7 @@ namespace Exiled.CustomRoles.API.Features
                 Registered.Add(this);
                 Init();
 
-                Log.Debug($"{Name} ({Id}) has been successfully registered.", CustomRoles.Instance.Config.Debug);
+                Log.Debug($"{Name} ({Id}) has been successfully registered.");
 
                 return true;
             }
@@ -700,7 +700,7 @@ namespace Exiled.CustomRoles.API.Features
         /// </summary>
         protected virtual void SubscribeEvents()
         {
-            Log.Debug($"{Name}: Loading events.", CustomRoles.Instance.Config.Debug);
+            Log.Debug($"{Name}: Loading events.");
             Exiled.Events.Handlers.Player.ChangingRole += OnInternalChangingRole;
             Exiled.Events.Handlers.Player.Dying += OnInternalDying;
         }
@@ -713,7 +713,7 @@ namespace Exiled.CustomRoles.API.Features
             foreach (Player player in TrackedPlayers)
                 RemoveRole(player);
 
-            Log.Debug($"{Name}: Unloading events.", CustomRoles.Instance.Config.Debug);
+            Log.Debug($"{Name}: Unloading events.");
             Exiled.Events.Handlers.Player.ChangingRole -= OnInternalChangingRole;
             Exiled.Events.Handlers.Player.Dying -= OnInternalDying;
         }

--- a/Exiled.Events/Commands/Config/Merge.cs
+++ b/Exiled.Events/Commands/Config/Merge.cs
@@ -39,16 +39,16 @@ namespace Exiled.Events.Commands.Config
         /// <inheritdoc/>
         public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            if (Loader.Config.ConfigType == ConfigType.Default)
+            if (LoaderPlugin.Config.ConfigType == ConfigType.Default)
             {
-                response = "Configs are actually merged.";
+                response = "Configs are already merged.";
                 return false;
             }
 
             SortedDictionary<string, IConfig> configs = ConfigManager.LoadSorted(ConfigManager.Read());
-            Loader.Config.ConfigType = ConfigType.Default;
+            LoaderPlugin.Config.ConfigType = ConfigType.Default;
             bool haveBeenSaved = ConfigManager.Save(configs);
-            File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(Loader.Config));
+            File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(LoaderPlugin.Config));
 
             response = $"Configs have been merged successfully! Feel free to remove the directory in the following path:\n\"{Paths.IndividualConfigs}\"";
             return haveBeenSaved;

--- a/Exiled.Events/Commands/Config/Split.cs
+++ b/Exiled.Events/Commands/Config/Split.cs
@@ -39,16 +39,16 @@ namespace Exiled.Events.Commands.Config
         /// <inheritdoc/>
         public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            if (Loader.Config.ConfigType == ConfigType.Separated)
+            if (LoaderPlugin.Config.ConfigType == ConfigType.Separated)
             {
-                response = "Configs are actually separated.";
+                response = "Configs are already separated.";
                 return false;
             }
 
             SortedDictionary<string, IConfig> configs = ConfigManager.LoadSorted(ConfigManager.Read());
-            Loader.Config.ConfigType = ConfigType.Separated;
+            LoaderPlugin.Config.ConfigType = ConfigType.Separated;
             bool haveBeenSaved = ConfigManager.Save(configs);
-            File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(Loader.Config));
+            File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(LoaderPlugin.Config));
 
             response = $"Configs have been merged successfully! Feel free to remove the file in the following path:\n\"{Paths.Config}\"";
             return haveBeenSaved;

--- a/Exiled.Events/Config.cs
+++ b/Exiled.Events/Config.cs
@@ -15,8 +15,10 @@ namespace Exiled.Events
     public sealed class Config : IConfig
     {
         /// <inheritdoc/>
-        [Description("Indicates whether the plugin is enabled or not")]
         public bool IsEnabled { get; set; } = true;
+
+        /// <inheritdoc/>
+        public bool Debug { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether SCP-173 can be blocked or not by the tutorial.

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -131,7 +131,7 @@ namespace Exiled.Events
                 Harmony.DEBUG = true;
 #endif
                 if (PatchByAttributes())
-                    Log.Debug("Events patched successfully!", Loader.ShouldDebugBeShown);
+                    Log.Debug("Events patched successfully!");
                 else
                     Log.Error($"Patching failed!");
 #if DEBUG
@@ -162,10 +162,10 @@ namespace Exiled.Events
         /// </summary>
         public void Unpatch()
         {
-            Log.Debug("Unpatching events...", Loader.ShouldDebugBeShown);
+            Log.Debug("Unpatching events...");
             Harmony.UnpatchAll();
 
-            Log.Debug("All events have been unpatched complete. Goodbye!", Loader.ShouldDebugBeShown);
+            Log.Debug("All events have been unpatched complete. Goodbye!");
         }
 
         private bool PatchByAttributes()
@@ -174,7 +174,7 @@ namespace Exiled.Events
             {
                 Harmony.PatchAll();
 
-                Log.Debug("Events patched by attributes successfully!", Loader.ShouldDebugBeShown);
+                Log.Debug("Events patched by attributes successfully!");
                 return true;
             }
             catch (Exception exception)

--- a/Exiled.Events/Patches/Events/Server/RestartingRound.cs
+++ b/Exiled.Events/Patches/Events/Server/RestartingRound.cs
@@ -39,8 +39,7 @@ namespace Exiled.Events.Patches.Events.Server
 
                     // API.Features.Log.Debug("Round restarting", Loader.ShouldDebugBeShown)
                     new(OpCodes.Ldstr, "Round restarting"),
-                    new(OpCodes.Call, PropertyGetter(typeof(Loader), nameof(Loader.ShouldDebugBeShown))),
-                    new(OpCodes.Call, Method(typeof(API.Features.Log), nameof(API.Features.Log.Debug), new[] { typeof(string), typeof(bool) })),
+                    new(OpCodes.Call, Method(typeof(API.Features.Log), nameof(API.Features.Log.Debug), new[] { typeof(string) })),
                 });
 
             const int offset = 1;

--- a/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -66,7 +66,7 @@ namespace Exiled.Events.Patches.Generic
 
             if (attackerHub is null || victimHub is null)
             {
-                Log.Debug($"CheckFriendlyFirePlayerRules, Attacker hub null: {attackerHub is null}, Victim hub null: {victimHub is null}", Loader.Loader.ShouldDebugBeShown);
+                Log.Debug($"CheckFriendlyFirePlayerRules, Attacker hub null: {attackerHub is null}, Victim hub null: {victimHub is null}");
                 return true;
             }
 
@@ -76,17 +76,17 @@ namespace Exiled.Events.Patches.Generic
                 Player victim = Player.Get(victimHub);
                 if (attacker is null || victim is null)
                 {
-                    Log.Debug($"CheckFriendlyFirePlayerRules, Attacker null: {attacker is null}, Victim null: {victim is null}", Loader.Loader.ShouldDebugBeShown);
+                    Log.Debug($"CheckFriendlyFirePlayerRules, Attacker null: {attacker is null}, Victim null: {victim is null}");
                     return true;
                 }
 
                 if (attacker == victim)
                 {
-                    Log.Debug("CheckFriendlyFirePlayerRules, Attacker player was equal to Victim, likely suicide", Loader.Loader.ShouldDebugBeShown);
+                    Log.Debug("CheckFriendlyFirePlayerRules, Attacker player was equal to Victim, likely suicide");
                     return true;
                 }
 
-                Log.Debug($"CheckFriendlyFirePlayerRules, Attacker role {attacker.Role} and Victim {victim.Role}", Loader.Loader.ShouldDebugBeShown);
+                Log.Debug($"CheckFriendlyFirePlayerRules, Attacker role {attacker.Role} and Victim {victim.Role}");
 
                 if (!string.IsNullOrEmpty(victim.UniqueRole))
                 {
@@ -131,7 +131,7 @@ namespace Exiled.Events.Patches.Generic
             }
             catch (Exception ex)
             {
-                Log.Debug($"CheckFriendlyFirePlayerRules failed to handle friendly fire because: {ex}", Loader.Loader.ShouldDebugBeShown);
+                Log.Debug($"CheckFriendlyFirePlayerRules failed to handle friendly fire because: {ex}");
             }
 
             return false;

--- a/Exiled.Example/Config.cs
+++ b/Exiled.Example/Config.cs
@@ -21,8 +21,10 @@ namespace Exiled.Example
     public sealed class Config : IConfig
     {
         /// <inheritdoc/>
-        [Description("Indicates whether the plugin is enabled or not")]
         public bool IsEnabled { get; set; } = true;
+
+        /// <inheritdoc />
+        public bool Debug { get; set; }
 
         /// <summary>
         /// Gets the string config.

--- a/Exiled.Loader/Config.cs
+++ b/Exiled.Loader/Config.cs
@@ -17,9 +17,13 @@ namespace Exiled.Loader
     /// </summary>
     public sealed class Config : IConfig
     {
-        /// <inheritdoc/>
-        [Description("Indicates whether the plugin is enabled or not")]
+        /// <inheritdoc />
+        [Description("Whether or not EXILED is enabled on this server.")]
         public bool IsEnabled { get; set; } = true;
+
+        /// <inheritdoc />
+        [Description("Whether or not debug messages should be shown.")]
+        public bool Debug { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether outdated plugins should be loaded or not.

--- a/Exiled.Loader/ConfigManager.cs
+++ b/Exiled.Loader/ConfigManager.cs
@@ -24,30 +24,6 @@ namespace Exiled.Loader
     public static class ConfigManager
     {
         /// <summary>
-        /// Loads the loader configs.
-        /// </summary>
-        public static void LoadLoaderConfigs()
-        {
-            if (!File.Exists(Paths.LoaderConfig))
-            {
-                Log.Warn("The Loader doesn't have default configs, generating...");
-                Directory.CreateDirectory(Paths.Configs);
-                File.WriteAllText(Paths.LoaderConfig, Loader.Serializer.Serialize(Loader.Config));
-                return;
-            }
-
-            try
-            {
-                Loader.Config.CopyProperties(Loader.Deserializer.Deserialize<Config>(File.ReadAllText(Paths.LoaderConfig)));
-            }
-            catch (Exception e)
-            {
-                Log.Error("Exiled.Loader configs could not be loaded, some of them are in a wrong format, default configs will be loaded instead!");
-                Log.Error(e);
-            }
-        }
-
-        /// <summary>
         /// Loads all plugin configs.
         /// </summary>
         /// <param name="rawConfigs">The raw configs to be loaded.</param>
@@ -56,7 +32,7 @@ namespace Exiled.Loader
         {
             try
             {
-                Log.Info($"Loading plugin configs... ({Loader.Config.ConfigType})");
+                Log.Info($"Loading plugin configs... ({LoaderPlugin.Config.ConfigType})");
 
                 Dictionary<string, object> rawDeserializedConfigs = Loader.Deserializer.Deserialize<Dictionary<string, object>>(rawConfigs) ?? new Dictionary<string, object>();
                 SortedDictionary<string, IConfig> deserializedConfigs = new(StringComparer.Ordinal);
@@ -91,7 +67,7 @@ namespace Exiled.Loader
         /// <param name="plugin">The plugin which config will be loaded.</param>
         /// <param name="rawConfigs">The raw configs to detect if the plugin already has generated configs.</param>
         /// <returns>The <see cref="IConfig"/> of the plugin.</returns>
-        public static IConfig LoadConfig(this IPlugin<IConfig> plugin, Dictionary<string, object> rawConfigs = null) => Loader.Config.ConfigType switch
+        public static IConfig LoadConfig(this IPlugin<IConfig> plugin, Dictionary<string, object> rawConfigs = null) => LoaderPlugin.Config.ConfigType switch
         {
             ConfigType.Separated => LoadSeparatedConfig(plugin),
             _ => LoadDefaultConfig(plugin, rawConfigs),
@@ -226,7 +202,7 @@ namespace Exiled.Loader
                 if (configs is null || configs.Count == 0)
                     return false;
 
-                if (Loader.Config.ConfigType == ConfigType.Default)
+                if (LoaderPlugin.Config.ConfigType == ConfigType.Default)
                 {
                     return SaveDefaultConfig(Loader.Serializer.Serialize(configs));
                 }
@@ -247,7 +223,7 @@ namespace Exiled.Loader
         /// <returns>Returns the read configs.</returns>
         public static string Read()
         {
-            if (Loader.Config.ConfigType != ConfigType.Default)
+            if (LoaderPlugin.Config.ConfigType != ConfigType.Default)
                 return string.Empty;
 
             try
@@ -271,7 +247,7 @@ namespace Exiled.Loader
         {
             try
             {
-                if (Loader.Config.ConfigType == ConfigType.Default)
+                if (LoaderPlugin.Config.ConfigType == ConfigType.Default)
                 {
                     SaveDefaultConfig(string.Empty);
                     return true;

--- a/Exiled.Loader/Exiled.Loader.csproj
+++ b/Exiled.Loader/Exiled.Loader.csproj
@@ -25,6 +25,7 @@
         <Reference Include="Assembly-CSharp" HintPath="$(BETA_EXILED_REFERENCES)\Assembly-CSharp-Publicized.dll" Private="false" />
         <Reference Include="Assembly-CSharp-firstpass" HintPath="$(BETA_EXILED_REFERENCES)\Assembly-CSharp-firstpass.dll" Private="false" />
         <Reference Include="NorthwoodLib" HintPath="$(BETA_EXILED_REFERENCES)\NorthwoodLib.dll" Private="false" />
+        <Reference Include="PluginAPI" HintPath="$(BETA_EXILED_REFERENCES)\PluginAPI.dll" Private="false" />
         <Reference Include="UnityEngine.AudioModule" HintPath="$(BETA_EXILED_REFERENCES)\UnityEngine.AudioModule.dll" Private="false" />
         <Reference Include="UnityEngine.CoreModule" HintPath="$(BETA_EXILED_REFERENCES)\UnityEngine.CoreModule.dll" Private="false" />
         <Reference Include="Mirror" HintPath="$(BETA_EXILED_REFERENCES)\Mirror.dll" Private="false" />

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -31,9 +31,12 @@ namespace Exiled.Loader
     /// <summary>
     /// Used to handle plugins.
     /// </summary>
-    public static class Loader
+    public class Loader
     {
-        static Loader()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Loader"/> class.
+        /// </summary>
+        public Loader()
         {
             Log.Info($"Initializing at {Environment.CurrentDirectory}");
 
@@ -52,10 +55,8 @@ namespace Exiled.Loader
 
             CustomNetworkManager.Modded = true;
 
-            ConfigManager.LoadLoaderConfigs();
-
-            if ((Config.Environment != EnvironmentType.Production) && (Config.Environment != EnvironmentType.ProductionDebug))
-                Paths.Reload($"EXILED-{Config.Environment.ToString().ToUpper()}");
+            if ((LoaderPlugin.Config.Environment != EnvironmentType.Production) && (LoaderPlugin.Config.Environment != EnvironmentType.ProductionDebug))
+                Paths.Reload($"EXILED-{LoaderPlugin.Config.Environment.ToString().ToUpper()}");
             if (Environment.CurrentDirectory.Contains("testing", StringComparison.OrdinalIgnoreCase))
                 Paths.Reload($"EXILED-Testing");
 
@@ -63,7 +64,7 @@ namespace Exiled.Loader
             Directory.CreateDirectory(Paths.Plugins);
             Directory.CreateDirectory(Paths.Dependencies);
 
-            if (Config.ConfigType == ConfigType.Separated)
+            if (LoaderPlugin.Config.ConfigType == ConfigType.Separated)
                 Directory.CreateDirectory(Paths.IndividualConfigs);
         }
 
@@ -71,11 +72,6 @@ namespace Exiled.Loader
         /// Gets the plugins list.
         /// </summary>
         public static SortedSet<IPlugin<IConfig>> Plugins { get; } = new(PluginPriorityComparer.Instance);
-
-        /// <summary>
-        /// Gets a dictionary that pairs assemblies with their associated plugins.
-        /// </summary>
-        public static Dictionary<Assembly, IPlugin<IConfig>> PluginAssemblies { get; } = new();
 
         /// <summary>
         /// Gets a dictionary containing the file paths of assemblies.
@@ -91,16 +87,6 @@ namespace Exiled.Loader
         /// Gets the version of the assembly.
         /// </summary>
         public static Version Version { get; } = Assembly.GetExecutingAssembly().GetName().Version;
-
-        /// <summary>
-        /// Gets the configs of the plugin manager.
-        /// </summary>
-        public static Config Config { get; } = new();
-
-        /// <summary>
-        /// Gets a value indicating whether the debug should be shown or not.
-        /// </summary>
-        public static bool ShouldDebugBeShown => Config.Environment == EnvironmentType.Testing || Config.Environment == EnvironmentType.Development || Config.Environment == EnvironmentType.ProductionDebug;
 
         /// <summary>
         /// Gets plugin dependencies.
@@ -134,44 +120,6 @@ namespace Exiled.Loader
             .Build();
 
         /// <summary>
-        /// Runs the plugin manager, by loading all dependencies, plugins, configs and then enables all plugins.
-        /// </summary>
-        /// <param name="dependencies">The dependencies that could have been loaded by Exiled.Bootstrap.</param>
-        public static void Run(Assembly[] dependencies = null)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? CheckUAC() : geteuid() == 0)
-            {
-                ServerConsole.AddLog("YOU ARE RUNNING THE SERVER AS ROOT / ADMINISTRATOR. THIS IS HIGHLY UNRECOMMENDED. PLEASE INSTALL YOUR SERVER AS A NON-ROOT/ADMIN USER.", ConsoleColor.Red);
-                Thread.Sleep(5000);
-            }
-
-            if (dependencies?.Length > 0)
-                Dependencies.AddRange(dependencies);
-
-            if (!Config.IsEnabled)
-            {
-                Log.Warn("Exiled Loader is disabled. No plugins will be loaded.");
-                return;
-            }
-
-            LoadDependencies();
-            LoadPlugins();
-
-            ConfigManager.Reload();
-            TranslationManager.Reload();
-
-            EnablePlugins();
-
-            BuildInfoCommand.ModDescription = string.Join(
-                "\n",
-                AppDomain.CurrentDomain.GetAssemblies()
-                    .Where(a => a.FullName.StartsWith("Exiled.", StringComparison.OrdinalIgnoreCase))
-                    .Select(a => $"{a.GetName().Name} - Version {a.GetName().Version.ToString(3)}"));
-
-            ServerConsole.AddLog($"Welcome to {LoaderMessages.GetMessage()}", ConsoleColor.Green);
-        }
-
-        /// <summary>
         /// Loads all plugins.
         /// </summary>
         public static void LoadPlugins()
@@ -200,7 +148,7 @@ namespace Exiled.Loader
 
                 Log.Info($"Loaded plugin {plugin.Name}@{(plugin.Version is not null ? $"{plugin.Version.Major}.{plugin.Version.Minor}.{plugin.Version.Build}" : attribute is not null ? attribute.InformationalVersion : string.Empty)}");
 
-                PluginAssemblies.Add(assembly, plugin);
+                Server.PluginAssemblies.Add(assembly, plugin);
                 Plugins.Add(plugin);
             }
         }
@@ -237,30 +185,30 @@ namespace Exiled.Loader
                 {
                     if (type.IsAbstract || type.IsInterface)
                     {
-                        Log.Debug($"\"{type.FullName}\" is an interface or abstract class, skipping.", ShouldDebugBeShown);
+                        Log.Debug($"\"{type.FullName}\" is an interface or abstract class, skipping.");
                         continue;
                     }
 
                     if (!IsDerivedFromPlugin(type))
                     {
-                        Log.Debug($"\"{type.FullName}\" does not inherit from Plugin<TConfig>, skipping.", ShouldDebugBeShown);
+                        Log.Debug($"\"{type.FullName}\" does not inherit from Plugin<TConfig>, skipping.");
                         continue;
                     }
 
-                    Log.Debug($"Loading type {type.FullName}", ShouldDebugBeShown);
+                    Log.Debug($"Loading type {type.FullName}");
 
                     IPlugin<IConfig> plugin = null;
 
                     ConstructorInfo constructor = type.GetConstructor(Type.EmptyTypes);
                     if (constructor is not null)
                     {
-                        Log.Debug("Public default constructor found, creating instance...", ShouldDebugBeShown);
+                        Log.Debug("Public default constructor found, creating instance...");
 
                         plugin = constructor.Invoke(null) as IPlugin<IConfig>;
                     }
                     else
                     {
-                        Log.Debug($"Constructor wasn't found, searching for a property with the {type.FullName} type...", ShouldDebugBeShown);
+                        Log.Debug($"Constructor wasn't found, searching for a property with the {type.FullName} type...");
 
                         object value = Array.Find(type.GetProperties(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public), property => property.PropertyType == type)?.GetValue(null);
 
@@ -275,7 +223,7 @@ namespace Exiled.Loader
                         continue;
                     }
 
-                    Log.Debug($"Instantiated type {type.FullName}", ShouldDebugBeShown);
+                    Log.Debug($"Instantiated type {type.FullName}");
 
                     if (CheckPluginRequiredExiledVersion(plugin))
                         continue;
@@ -365,7 +313,7 @@ namespace Exiled.Loader
             }
 
             Plugins.Clear();
-            PluginAssemblies.Clear();
+            Server.PluginAssemblies.Clear();
 
             LoadPlugins();
 
@@ -400,6 +348,38 @@ namespace Exiled.Loader
         /// <param name="args">The name or prefix of the plugin (Using the prefix is recommended).</param>
         /// <returns>The desired plugin, null if not found.</returns>
         public static IPlugin<IConfig> GetPlugin(string args) => Plugins.FirstOrDefault(x => x.Name == args || x.Prefix == args);
+
+        /// <summary>
+        /// Runs the plugin manager, by loading all dependencies, plugins, configs and then enables all plugins.
+        /// </summary>
+        /// <param name="dependencies">The dependencies that could have been loaded by Exiled.Bootstrap.</param>
+        public void Run(Assembly[] dependencies = null)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? CheckUAC() : geteuid() == 0)
+            {
+                ServerConsole.AddLog("YOU ARE RUNNING THE SERVER AS ROOT / ADMINISTRATOR. THIS IS HIGHLY UNRECOMMENDED. PLEASE INSTALL YOUR SERVER AS A NON-ROOT/ADMIN USER.", ConsoleColor.DarkRed);
+                Thread.Sleep(5000);
+            }
+
+            if (dependencies?.Length > 0)
+                Dependencies.AddRange(dependencies);
+
+            LoadDependencies();
+            LoadPlugins();
+
+            ConfigManager.Reload();
+            TranslationManager.Reload();
+
+            EnablePlugins();
+
+            BuildInfoCommand.ModDescription = string.Join(
+                "\n",
+                AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(a => a.FullName.StartsWith("Exiled.", StringComparison.OrdinalIgnoreCase))
+                    .Select(a => $"{a.GetName().Name} - Version {a.GetName().Version.ToString(3)}"));
+
+            ServerConsole.AddLog($"Welcome to {LoaderMessages.GetMessage()}", ConsoleColor.Green);
+        }
 
         /// <summary>
         /// Indicates that the passed type is derived from the plugin type.
@@ -448,7 +428,7 @@ namespace Exiled.Loader
 
                     return true;
                 }
-                else if ((requiredVersion.Major < actualVersion.Major) && !Config.ShouldLoadOutdatedPlugins)
+                else if ((requiredVersion.Major < actualVersion.Major) && !LoaderPlugin.Config.ShouldLoadOutdatedPlugins)
                 {
                     Log.Error(
                         $"You're running an older version of {plugin.Name} ({plugin.Version.ToString(3)})! " +

--- a/Exiled.Loader/LoaderPlugin.cs
+++ b/Exiled.Loader/LoaderPlugin.cs
@@ -1,0 +1,84 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="LoaderPlugin.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Loader
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+
+    using NorthwoodLib;
+    using PluginAPI.Core;
+    using PluginAPI.Core.Attributes;
+
+    /// <summary>
+    /// The PluginAPI Plugin class for the EXILED Loader.
+    /// </summary>
+    public class LoaderPlugin
+    {
+#pragma warning disable SA1401
+        /// <summary>
+        /// The config for the EXILED Loader.
+        /// </summary>
+        [PluginConfig]
+        public static Config Config;
+#pragma warning restore SA1401
+
+        private static Loader loader;
+
+        /// <summary>
+        /// Called by PluginAPI when the plugin is enabled.
+        /// </summary>
+        [PluginEntryPoint("Exiled Loader", null, "Loads the EXILED Plugin Framework.", "Exiled-Team")]
+        public void Enable()
+        {
+            if (!Config.IsEnabled)
+            {
+                Log.Info("EXILED is disabled on this server via config.");
+                return;
+            }
+
+            /* TODO: Implement this with a dictionary of Game versions and the exiled versions it is compatible with.
+            if (GameCore.Version.VersionString != "your mom")
+            {
+                Log.Error("EXILED is not compatible with this version of the game, aborting...");
+                return;
+            }*/
+
+            Log.Info($"Loading EXILED Version: {Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion}");
+
+            string rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "EXILED");
+
+            if (Environment.CurrentDirectory.Contains("testing", StringComparison.OrdinalIgnoreCase))
+            {
+                Log.Warning("Switching root patch to EXILED-Testing.");
+                rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "EXILED-Testing");
+            }
+
+            string dependenciesPath = Path.Combine(rootPath, "Plugins", "dependencies");
+
+            if (!Directory.Exists(rootPath))
+                Directory.CreateDirectory(rootPath);
+
+            if (!File.Exists(Path.Combine(dependenciesPath, "Exiled.API.dll")))
+            {
+                Log.Error($"[Exiled.Bootstrap] Exiled.API.dll was not found, Exiled won't be loaded!", "Exiled.Loader");
+                return;
+            }
+
+            if (!File.Exists(Path.Combine(dependenciesPath, "YamlDotNet.dll")))
+            {
+                ServerConsole.AddLog($"[Exiled.Bootstrap] YamlDotNet.dll was not found, Exiled won't be loaded!", ConsoleColor.DarkRed);
+                return;
+            }
+
+            loader = new Loader();
+            Log.Info("Calling run");
+            loader.Run();
+        }
+    }
+}

--- a/Exiled.Loader/TranslationManager.cs
+++ b/Exiled.Loader/TranslationManager.cs
@@ -32,7 +32,7 @@ namespace Exiled.Loader
         {
             try
             {
-                Log.Info($"Loading plugin translations... ({Loader.Config.ConfigType})");
+                Log.Info($"Loading plugin translations... ({LoaderPlugin.Config.ConfigType})");
 
                 Dictionary<string, object> rawDeserializedTranslations = Loader.Deserializer.Deserialize<Dictionary<string, object>>(rawTranslations) ?? new Dictionary<string, object>();
                 SortedDictionary<string, ITranslation> deserializedTranslations = new(StringComparer.Ordinal);
@@ -70,7 +70,7 @@ namespace Exiled.Loader
         /// <param name="plugin">The plugin which its translation has to be loaded.</param>
         /// <param name="rawTranslations">The raw translations to check whether or not the plugin already has a translation config.</param>
         /// <returns>The <see cref="ITranslation"/> of the desired plugin.</returns>
-        public static ITranslation LoadTranslation(this IPlugin<IConfig> plugin, Dictionary<string, object> rawTranslations = null) => Loader.Config.ConfigType switch
+        public static ITranslation LoadTranslation(this IPlugin<IConfig> plugin, Dictionary<string, object> rawTranslations = null) => LoaderPlugin.Config.ConfigType switch
         {
             ConfigType.Separated => plugin.LoadSeparatedTranslation(),
             _ => plugin.LoadDefaultTranslation(rawTranslations),
@@ -140,7 +140,7 @@ namespace Exiled.Loader
                 if (translations is null || translations.Count == 0)
                     return false;
 
-                if (Loader.Config.ConfigType == ConfigType.Default)
+                if (LoaderPlugin.Config.ConfigType == ConfigType.Default)
                 {
                     return SaveDefaultTranslation(Loader.Serializer.Serialize(translations));
                 }
@@ -161,7 +161,7 @@ namespace Exiled.Loader
         /// <returns>Returns the read translations.</returns>
         public static string Read()
         {
-            if (Loader.Config.ConfigType != ConfigType.Default)
+            if (LoaderPlugin.Config.ConfigType != ConfigType.Default)
                 return string.Empty;
 
             try
@@ -185,7 +185,7 @@ namespace Exiled.Loader
         {
             try
             {
-                if (Loader.Config.ConfigType == ConfigType.Default)
+                if (LoaderPlugin.Config.ConfigType == ConfigType.Default)
                 {
                     SaveDefaultTranslation(string.Empty);
                     return true;

--- a/Exiled.Permissions/Config.cs
+++ b/Exiled.Permissions/Config.cs
@@ -44,7 +44,9 @@ namespace Exiled.Permissions
         public string FullPath { get; private set; }
 
         /// <inheritdoc/>
-        [Description("Indicates whether the plugin is enabled or not")]
         public bool IsEnabled { get; set; } = true;
+
+        /// <inheritdoc/>
+        public bool Debug { get; set; }
     }
 }

--- a/Exiled.Permissions/Extensions/Permissions.cs
+++ b/Exiled.Permissions/Extensions/Permissions.cs
@@ -135,12 +135,12 @@ namespace Exiled.Permissions.Extensions
 
                     group.Value.CombinedPermissions = group.Value.Permissions.Union(inheritedPerms).ToList();
 
-                    Log.Debug($"{group.Key} permissions loaded.", Instance.Config.ShouldDebugBeShown);
+                    Log.Debug($"{group.Key} permissions loaded.");
                 }
                 catch (Exception e)
                 {
                     Log.Error($"Failed to load permissions/inheritance for: {group.Key}.\n{e.Message}.\nMake sure your config file is setup correctly, every group defined must include inheritance and permissions values, even if they are empty.");
-                    Log.Debug($"{e}", Instance.Config.ShouldDebugBeShown);
+                    Log.Debug($"{e}");
                 }
             }
         }
@@ -191,21 +191,21 @@ namespace Exiled.Permissions.Extensions
             if (player is null || player.GameObject == null || Groups is null || Groups.Count == 0)
                 return false;
 
-            Log.Debug($"UserID: {player.UserId} | PlayerId: {player.Id}", Instance.Config.ShouldDebugBeShown);
-            Log.Debug($"Permission string: {permission}", Instance.Config.ShouldDebugBeShown);
+            Log.Debug($"UserID: {player.UserId} | PlayerId: {player.Id}");
+            Log.Debug($"Permission string: {permission}");
 
             string plyGroupKey = player.Group is not null ? ServerStatic.GetPermissionsHandler()._groups.FirstOrDefault(g => g.Value.EqualsTo(player.Group)).Key : null;
-            Log.Debug($"GroupKey: {plyGroupKey ?? "(null)"}", Instance.Config.ShouldDebugBeShown);
+            Log.Debug($"GroupKey: {plyGroupKey ?? "(null)"}");
 
             if (plyGroupKey is null || !Groups.TryGetValue(plyGroupKey, out Group group))
             {
-                Log.Debug("The source group is null, the default group is used", Instance.Config.ShouldDebugBeShown);
+                Log.Debug("The source group is null, the default group is used");
                 group = DefaultGroup;
             }
 
             if (group is null)
             {
-                Log.Debug("There's no default group, returning false...", Instance.Config.ShouldDebugBeShown);
+                Log.Debug("There's no default group, returning false...");
                 return false;
             }
 
@@ -255,14 +255,14 @@ namespace Exiled.Permissions.Extensions
 
                 StringBuilderPool.Shared.Return(strBuilder);
 
-                Log.Debug($"Result in the block: {result}", Instance.Config.ShouldDebugBeShown);
+                Log.Debug($"Result in the block: {result}");
                 return result;
             }
 
             // It'll work when there is no dot in the permission.
             bool result2 = group.CombinedPermissions.Contains(permission, StringComparison.OrdinalIgnoreCase);
 
-            Log.Debug($"Result outside the block: {result2}", Instance.Config.ShouldDebugBeShown);
+            Log.Debug($"Result outside the block: {result2}");
 
             return result2;
         }

--- a/Exiled.Updater/Config.cs
+++ b/Exiled.Updater/Config.cs
@@ -16,8 +16,10 @@ namespace Exiled.Updater
     public sealed class Config : IConfig
     {
         /// <inheritdoc/>
-        [Description("Indicates whether the plugin is enabled or not")]
         public bool IsEnabled { get; set; } = true;
+
+        /// <inheritdoc/>
+        public bool Debug { get; set; }
 
         [Description("Indicates whether the debug should be shown or not")]
         public bool ShouldDebugBeShown { get; internal set; } = false;


### PR DESCRIPTION
- Turn Exiled.Loader into a NWAPI plugin.
- Added Debug bool to IConfig
- Log.Debug() will now get the value of the plugin's debug config bool automatically.
- For assemblies that are not plugin assemblies (Exiled.API, Log.Debug inside of Harmony patches, etc) it will attempt to use the Debug value from the Events dll through reflection. If it can't, it will default to false.
- If Exiled.API is built in Debug instead of Release, all debug messages are shown. (Useful when testing Exiled.API without the events plugin, if it's being used by itself, which is something it can't do currently but I will be fixing that)
- Obsoletes Exiled.Bootstrap.dll and the need to patch server assemblies for users to use EXILED.