### PR TITLE
Moved Player::SetRole to the Role Class and changed its name to Set (Role::Set) & Added Server::Frametime

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -490,10 +490,10 @@ namespace Exiled.API.Features
         /// This role is automatically cached until it changes, and it is recommended to use this propertly directly rather than storing the property yourself.
         /// </para>
         /// <para>
-        /// Roles and RoleTypeIds can be compared directly. <c>Player.Role == RoleTypeId.Scp079</c> is valid and will return <see langword="true"/> if the player is SCP-079. To set the player's role, see <see cref="SetRole(RoleTypeId, SpawnReason)"/>.
+        /// Roles and RoleTypeIds can be compared directly. <c>Player.Role == RoleTypeId.Scp079</c> is valid and will return <see langword="true"/> if the player is SCP-079. To set the player's role, see <see cref="Role.Set(RoleTypeId, SpawnReason)"/>.
         /// </para>
         /// </summary>
-        /// <seealso cref="SetRole(RoleTypeId, SpawnReason)"/>
+        /// <seealso cref="Role.Set(RoleTypeId, SpawnReason)"/>
         public Role Role
         {
             get => role ??= Role.Create(this, RoleTypeId.None);
@@ -1576,13 +1576,6 @@ namespace Exiled.API.Features
             Inventory.SetDisarmedStatus(null);
             new DisarmedPlayersListMessage(DisarmedPlayers.Entries).SendToAuthenticated();
         }
-
-        /// <summary>
-        /// Sets the player's <see cref="RoleTypeId"/>.
-        /// </summary>
-        /// <param name="newRole">The new <see cref="RoleTypeId"/> to be set.</param>
-        /// <param name="reason">The <see cref="SpawnReason"/> defining why the player's role was changed.</param>
-        public void SetRole(RoleTypeId newRole, SpawnReason reason = SpawnReason.ForceClass) => RoleManager.ServerSetRole(newRole, (RoleChangeReason)reason);
 
         /// <summary>
         /// Broadcasts the given <see cref="Features.Broadcast"/> to the player.

--- a/Exiled.API/Features/Roles/Role.cs
+++ b/Exiled.API/Features/Roles/Role.cs
@@ -216,6 +216,13 @@ namespace Exiled.API.Features.Roles
         public override int GetHashCode() => base.GetHashCode();
 
         /// <summary>
+        /// Sets the player's <see cref="RoleTypeId"/>.
+        /// </summary>
+        /// <param name="newRole">The new <see cref="RoleTypeId"/> to be set.</param>
+        /// <param name="reason">The <see cref="SpawnReason"/> defining why the player's role was changed.</param>
+        public virtual void Set(RoleTypeId newRole, SpawnReason reason = Enums.SpawnReason.ForceClass) => Owner.RoleManager.ServerSetRole(newRole, (RoleChangeReason)reason);
+
+        /// <summary>
         /// Creates a role from <see cref="RoleTypeId"/> and <see cref="Player"/>.
         /// </summary>
         /// <param name="owner">The <see cref="Player"/>.</param>

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -107,6 +107,11 @@ namespace Exiled.API.Features
         public static double Tps => Math.Round(1f / Time.smoothDeltaTime);
 
         /// <summary>
+        /// Gets the actual frametime of the server.
+        /// </summary>
+        public static double Frametime => Math.Round(1f / Time.deltaTime);
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not friendly fire is enabled.
         /// </summary>
         /// <seealso cref="Player.IsFriendlyFireEnabled"/>

--- a/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -403,7 +403,7 @@ namespace Exiled.CustomRoles.API.Features
             Log.Debug($"{Name}: Adding role to {player.Nickname}.");
 
             if (Role != RoleTypeId.None)
-                player.SetRole(Role, SpawnReason.ForceClass);
+                player.Role.Set(Role, SpawnReason.ForceClass);
 
             Timing.CallDelayed(
                 1.5f,
@@ -473,7 +473,7 @@ namespace Exiled.CustomRoles.API.Features
             player.InfoArea |= PlayerInfoArea.Role;
             player.Scale = Vector3.one;
             if (RemovalKillsPlayer)
-                player.SetRole(RoleTypeId.Spectator);
+                player.Role.Set(RoleTypeId.Spectator);
             foreach (CustomAbility ability in CustomAbilities)
             {
                 ability.RemoveAbility(player);


### PR DESCRIPTION
I always wanted the SetRole Method in the Role Class, bcs if you're setting the Role of the player to another role, you know XD

The changes have been testes with the following coroutine:

```
        private IEnumerator<float> ChangeRole()
        {
            yield return Timing.WaitForSeconds(5f);
            foreach (Player player in Player.List)
            {
                Log.Info("First role: " + player.Nickname);
                player.Role.Set(RoleTypeId.Scientist);
            }

            yield return Timing.WaitForSeconds(15f);
            foreach (Player player in Player.List)
            {
                Log.Info("Second role: " + player.Nickname);
                player.Role.Set(RoleTypeId.ClassD);
            }
        }
```

No errors regarding events and api found during the testing.