### PR TITLE
PickupAPI fixes

### DIFF
--- a/Exiled.API/Features/Items/ExplosiveGrenade.cs
+++ b/Exiled.API/Features/Items/ExplosiveGrenade.cs
@@ -104,11 +104,6 @@ namespace Exiled.API.Features.Items
         }
 
         /// <summary>
-        /// Gets or sets all the currently known <see cref="EffectGrenade"/>:<see cref="Throwable"/> items.
-        /// </summary>
-        internal static Dictionary<ExplosionGrenade, ExplosiveGrenade> GrenadeToItem { get; set; } = new();
-
-        /// <summary>
         /// Spawns an active grenade on the map at the specified location.
         /// </summary>
         /// <param name="position">The location to spawn the grenade.</param>

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -7,15 +7,12 @@
 
 namespace Exiled.API.Features.Items
 {
-    using System.Collections.Generic;
+    using Exiled.API.Enums;
+    using Exiled.API.Features.Pickups;
+    using Exiled.API.Features.Pickups.Projectiles;
 
-    using Enums;
-
-    using Footprinting;
-
+    using InventorySystem.Items;
     using InventorySystem.Items.ThrowableProjectiles;
-
-    using Mirror;
 
     using UnityEngine;
 
@@ -33,11 +30,7 @@ namespace Exiled.API.Features.Items
         public FlashGrenade(ThrowableItem itemBase)
             : base(itemBase)
         {
-            FlashbangGrenade grenade = (FlashbangGrenade)Base.Projectile;
-            BlindCurve = grenade._blindingOverDistance;
-            SurfaceDistanceIntensifier = grenade._surfaceZoneDistanceIntensifier;
-            DeafenCurve = grenade._deafenDurationOverDistance;
-            FuseTime = grenade._fuseTime;
+            Projectile = (FlashbangProjectile)((Throwable)this).Projectile;
         }
 
         /// <summary>
@@ -51,61 +44,92 @@ namespace Exiled.API.Features.Items
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="AnimationCurve"/> for determining how long the <see cref="EffectType.Blinded"/> effect will last.
+        /// Gets a <see cref="FlashbangProjectile"/> to change grenade properties.
         /// </summary>
-        public AnimationCurve BlindCurve { get; set; }
+        public new FlashbangProjectile Projectile { get; }
 
         /// <summary>
-        /// Gets or sets the multiplier for damage against <see cref="Side.Scp"/> players.
+        /// Gets or sets the minimum duration of player can take the effect.
         /// </summary>
-        public float SurfaceDistanceIntensifier { get; set; }
+        public float MinimalDurationEffect
+        {
+            get => Projectile.MinimalDurationEffect;
+            set => Projectile.MinimalDurationEffect = value;
+        }
 
         /// <summary>
-        /// Gets or sets the <see cref="AnimationCurve"/> for determining how long the <see cref="EffectType.Deafened"/> effect will last.
+        /// Gets or sets the additional duration of the <see cref="EffectType.Blinded"/> effect.
         /// </summary>
-        public AnimationCurve DeafenCurve { get; set; }
+        public float AdditionalBlindedEffect
+        {
+            get => Projectile.AdditionalBlindedEffect;
+            set => Projectile.AdditionalBlindedEffect = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the how mush the flash grenade going to be intensified when explode at <see cref="RoomType.Surface"/>.
+        /// </summary>
+        public float SurfaceDistanceIntensifier
+        {
+            get => Projectile.SurfaceDistanceIntensifier;
+            set => Projectile.SurfaceDistanceIntensifier = value;
+        }
 
         /// <summary>
         /// Gets or sets how long the fuse will last.
         /// </summary>
-        public float FuseTime { get; set; }
-
-        /// <summary>
-        /// Gets or sets all the currently known <see cref="EffectGrenade"/>:<see cref="Throwable"/> items.
-        /// </summary>
-        internal static Dictionary<FlashbangGrenade, FlashGrenade> GrenadeToItem { get; set; } = new();
+        public float FuseTime
+        {
+            get => Projectile.FuseTime;
+            set => Projectile.FuseTime = value;
+        }
 
         /// <summary>
         /// Spawns an active grenade on the map at the specified location.
         /// </summary>
         /// <param name="position">The location to spawn the grenade.</param>
         /// <param name="owner">Optional: The <see cref="Player"/> owner of the grenade.</param>
-        public void SpawnActive(Vector3 position, Player owner = null)
+        /// <returns>Spawned <see cref="FlashbangProjectile">grenade</see>.</returns>
+        public FlashbangProjectile SpawnActive(Vector3 position, Player owner = null)
         {
 #if DEBUG
             Log.Debug($"Spawning active grenade: {FuseTime}");
 #endif
-            FlashbangGrenade grenade = (FlashbangGrenade)Object.Instantiate(Base.Projectile, position, Quaternion.identity);
-            grenade.PreviousOwner = new Footprint(owner is not null ? owner.ReferenceHub : Server.Host.ReferenceHub);
-            grenade._blindingOverDistance = BlindCurve;
-            grenade._surfaceZoneDistanceIntensifier = SurfaceDistanceIntensifier;
-            grenade._deafenDurationOverDistance = DeafenCurve;
-            grenade._fuseTime = FuseTime;
-            NetworkServer.Spawn(grenade.gameObject);
-            grenade.ServerActivate();
+            FlashbangProjectile grenade = (FlashbangProjectile)Pickup.Get(Object.Instantiate(Projectile.Base, position, Quaternion.identity));
+
+            grenade.Serial = ItemSerialGenerator.GenerateNext();
+
+            grenade.MinimalDurationEffect = MinimalDurationEffect;
+            grenade.AdditionalBlindedEffect = AdditionalBlindedEffect;
+            grenade.SurfaceDistanceIntensifier = SurfaceDistanceIntensifier;
+            grenade.FuseTime = FuseTime;
+
+            grenade.PreviousOwner = owner ?? Server.Host;
+
+            grenade.Spawn();
+            grenade.Base.ServerActivate();
+
+            return grenade;
         }
 
         /// <summary>
         /// Clones current <see cref="FlashGrenade"/> object.
         /// </summary>
         /// <returns> New <see cref="FlashGrenade"/> object. </returns>
-        public override Item Clone() => new FlashGrenade()
+        public override Item Clone()
         {
-            BlindCurve = BlindCurve,
-            SurfaceDistanceIntensifier = SurfaceDistanceIntensifier,
-            DeafenCurve = DeafenCurve,
-            FuseTime = FuseTime,
-        };
+            FlashGrenade cloneableItem = new()
+            {
+                MinimalDurationEffect = MinimalDurationEffect,
+                AdditionalBlindedEffect = AdditionalBlindedEffect,
+                SurfaceDistanceIntensifier = SurfaceDistanceIntensifier,
+                FuseTime = FuseTime,
+                Repickable = Repickable,
+                PinPullTime = PinPullTime,
+            };
+
+            return cloneableItem;
+        }
 
         /// <summary>
         /// Returns the FlashGrenade in a human readable format.

--- a/Exiled.API/Features/Items/FlashGrenade.cs
+++ b/Exiled.API/Features/Items/FlashGrenade.cs
@@ -116,20 +116,13 @@ namespace Exiled.API.Features.Items
         /// Clones current <see cref="FlashGrenade"/> object.
         /// </summary>
         /// <returns> New <see cref="FlashGrenade"/> object. </returns>
-        public override Item Clone()
+        public override Item Clone() => new FlashGrenade()
         {
-            FlashGrenade cloneableItem = new()
-            {
-                MinimalDurationEffect = MinimalDurationEffect,
-                AdditionalBlindedEffect = AdditionalBlindedEffect,
-                SurfaceDistanceIntensifier = SurfaceDistanceIntensifier,
-                FuseTime = FuseTime,
-                Repickable = Repickable,
-                PinPullTime = PinPullTime,
-            };
-
-            return cloneableItem;
-        }
+            BlindCurve = BlindCurve,
+            SurfaceDistanceIntensifier = SurfaceDistanceIntensifier,
+            DeafenCurve = DeafenCurve,
+            FuseTime = FuseTime,
+        };
 
         /// <summary>
         /// Returns the FlashGrenade in a human readable format.

--- a/Exiled.API/Features/Items/Throwable.cs
+++ b/Exiled.API/Features/Items/Throwable.cs
@@ -30,7 +30,7 @@ namespace Exiled.API.Features.Items
             Base.Projectile.gameObject.SetActive(false);
             Projectile = Pickup.Get(Object.Instantiate(Base.Projectile)) as Projectile;
             Base.Projectile.gameObject.SetActive(true);
-            Projectile.Base.Info.Serial = Serial;
+            Projectile.Serial = Serial;
         }
 
         /// <summary>

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -107,7 +107,8 @@ namespace Exiled.API.Features.Pickups
             set
             {
                 Base.Info.Serial = value;
-                Base.NetworkInfo = Base.Info;
+                if (IsSpawned)
+                    Base.NetworkInfo = Base.Info;
             }
         }
 

--- a/Exiled.API/Features/Pickups/Pickup.cs
+++ b/Exiled.API/Features/Pickups/Pickup.cs
@@ -107,6 +107,7 @@ namespace Exiled.API.Features.Pickups
             set
             {
                 Base.Info.Serial = value;
+
                 if (IsSpawned)
                     Base.NetworkInfo = Base.Info;
             }

--- a/Exiled.Installer/Program.cs
+++ b/Exiled.Installer/Program.cs
@@ -50,8 +50,7 @@ namespace Exiled.Installer
 
         private static readonly string Header = $"{Assembly.GetExecutingAssembly().GetName().Name}-{Assembly.GetExecutingAssembly().GetName().Version}";
 
-        private static readonly GitHubClient GitHubClient = new(
-            new ProductHeaderValue(Header));
+        private static readonly GitHubClient GitHubClient = new(new ProductHeaderValue(Header));
 
         // Force use of LF because the file uses LF
         private static readonly Dictionary<string, string> Markup = Resources.Markup.Trim().Split('\n').ToDictionary(s => s.Split(':')[0], s => s.Split(':', 2)[1]);


### PR DESCRIPTION
- Deleted useless `GrenadeToItem` property
- Fixed cringe old api for `FlashGrenade`
- Fixed exception when setting serial to non-spawned items