### PR TITLE
load embedded dependencies automatically

### DIFF
--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -10,6 +10,7 @@ namespace Exiled.Loader
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.IO.Compression;
     using System.Linq;
     using System.Reflection;
     using System.Runtime.InteropServices;
@@ -153,7 +154,9 @@ namespace Exiled.Loader
         {
             try
             {
-                return Assembly.Load(File.ReadAllBytes(path));
+                Assembly assembly = Assembly.Load(File.ReadAllBytes(path));
+                ResolveAssemblyEmbeddedResources(assembly);
+                return assembly;
             }
             catch (Exception exception)
             {
@@ -428,6 +431,65 @@ namespace Exiled.Loader
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Attempts to load Embedded (compressed) assemblies from specified Assembly.
+        /// </summary>
+        /// <param name="target">Assembly to check for embedded assemblies.</param>
+        private static void ResolveAssemblyEmbeddedResources(Assembly target)
+        {
+            try
+            {
+                Log.Debug($"Attempting to load embedded resources for {target.FullName}");
+
+                string[] resourceNames = target.GetManifestResourceNames();
+                foreach (string name in resourceNames)
+                {
+                    Log.Debug($"Found resource {name}");
+                    if (name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        using (MemoryStream stream = new MemoryStream())
+                        {
+                            Log.Debug($"Loading resource {name}");
+                            Stream dataStream = target.GetManifestResourceStream(name);
+                            if (dataStream == null)
+                            {
+                                Log.Error($"Unable to resolve resource {name} Stream was null");
+                                continue;
+                            }
+
+                            dataStream.CopyTo(stream);
+                            Assembly assembly = Assembly.Load(stream.ToArray());
+                            Dependencies.Add(assembly);
+                            Log.Debug($"Loaded resource {name}");
+                        }
+                    }
+                    else if (name.EndsWith(".dll.compressed", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Stream dataStream = target.GetManifestResourceStream(name);
+                        if (dataStream == null)
+                        {
+                            Log.Error($"Unable to resolve resource {name} Stream was null");
+                            continue;
+                        }
+
+                        using (DeflateStream stream = new DeflateStream(dataStream, CompressionMode.Decompress))
+                        using (MemoryStream memStream = new MemoryStream())
+                        {
+                            Log.Debug($"Loading resource {name}");
+                            stream.CopyTo(memStream);
+                            Assembly assembly = Assembly.Load(memStream.ToArray());
+                            Dependencies.Add(assembly);
+                            Log.Debug($"Loaded resource {name}");
+                        }
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                Log.Error($"Failed to load embedded resources from {target.FullName}: {exception}");
+            }
         }
 
 #pragma warning disable SA1201

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -155,7 +155,9 @@ namespace Exiled.Loader
             try
             {
                 Assembly assembly = Assembly.Load(File.ReadAllBytes(path));
+                
                 ResolveAssemblyEmbeddedResources(assembly);
+
                 return assembly;
             }
             catch (Exception exception)

--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -446,15 +446,19 @@ namespace Exiled.Loader
                 Log.Debug($"Attempting to load embedded resources for {target.FullName}");
 
                 string[] resourceNames = target.GetManifestResourceNames();
+                
                 foreach (string name in resourceNames)
                 {
                     Log.Debug($"Found resource {name}");
+                    
                     if (name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                     {
                         using (MemoryStream stream = new MemoryStream())
                         {
                             Log.Debug($"Loading resource {name}");
+                            
                             Stream dataStream = target.GetManifestResourceStream(name);
+                            
                             if (dataStream == null)
                             {
                                 Log.Error($"Unable to resolve resource {name} Stream was null");
@@ -462,14 +466,16 @@ namespace Exiled.Loader
                             }
 
                             dataStream.CopyTo(stream);
-                            Assembly assembly = Assembly.Load(stream.ToArray());
-                            Dependencies.Add(assembly);
+
+                            Dependencies.Add(Assembly.Load(stream.ToArray()));
+                            
                             Log.Debug($"Loaded resource {name}");
                         }
                     }
                     else if (name.EndsWith(".dll.compressed", StringComparison.OrdinalIgnoreCase))
                     {
                         Stream dataStream = target.GetManifestResourceStream(name);
+                        
                         if (dataStream == null)
                         {
                             Log.Error($"Unable to resolve resource {name} Stream was null");
@@ -480,9 +486,11 @@ namespace Exiled.Loader
                         using (MemoryStream memStream = new MemoryStream())
                         {
                             Log.Debug($"Loading resource {name}");
+                            
                             stream.CopyTo(memStream);
-                            Assembly assembly = Assembly.Load(memStream.ToArray());
-                            Dependencies.Add(assembly);
+
+                            Dependencies.Add(Assembly.Load(memStream.ToArray()));
+                            
                             Log.Debug($"Loaded resource {name}");
                         }
                     }


### PR DESCRIPTION
Load dependencies that are embeded into an assembly automatically.
In some cases plugins (or dependencies) that use CosturaFody to package their dependencies may fail to load if a Type from a dependency is inherited.

![afbeelding](https://user-images.githubusercontent.com/44529860/210101613-73b1ced3-b510-40b4-b02b-d76db3eacbef.png)

This PR will allow plugins that use CosturaFody to package their dependencies to work in cases of inheriting a Type from a dependency.