### PR TITLE
Revert of PluginAPI events usage

### DIFF
--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -684,16 +684,12 @@ namespace Exiled.Events.Handlers
         /// Called before a <see cref="API.Features.Player"/> interacts with an elevator.
         /// </summary>
         /// <param name="ev">The <see cref="InteractingElevatorEventArgs"/> instance.</param>
-        // [PluginEvent(ServerEventType.PlayerInteractElevator)]
-        // TODO: Can't be implemented right now. Missing Elevator argument.
         public static void OnInteractingElevator(InteractingElevatorEventArgs ev) => InteractingElevator.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> interacts with a locker.
         /// </summary>
         /// <param name="ev">The <see cref="InteractingLockerEventArgs"/> instance.</param>
-        // [PluginEvent(ServerEventType.PlayerInteractLocker)]
-        // TODO: Can't be implemented right now. Missing LockerChamber argument.
         public static void OnInteractingLocker(InteractingLockerEventArgs ev) => InteractingLocker.InvokeSafely(ev);
 
         /// <summary>
@@ -706,8 +702,6 @@ namespace Exiled.Events.Handlers
         /// Called before a <see cref="API.Features.Player"/> receives a status effect.
         /// </summary>
         /// <param name="ev">The <see cref="ReceivingEffectEventArgs"/> instance.</param>
-        // [PluginEvent(ServerEventType.PlayerReceiveEffect)]
-        // TODO: Can't be implemented right now. Missing effect properties.
         public static void OnReceivingEffect(ReceivingEffectEventArgs ev) => ReceivingEffect.InvokeSafely(ev);
 
         /// <summary>
@@ -732,24 +726,18 @@ namespace Exiled.Events.Handlers
         /// Called before processing a hotkey.
         /// </summary>
         /// <param name="ev">The <see cref="ProcessingHotkeyEventArgs"/> instance.</param>
-        // [PluginEvent(ServerEventType.PlayerUseHotkey)]
-        // TODO: Can't be implemented right now. Looks like our enum is outdated. We can also use NW's one.
         public static void OnProcessingHotkey(ProcessingHotkeyEventArgs ev) => ProcessingHotkey.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> interacts with a shooting target.
         /// </summary>
         /// <param name="ev">The <see cref="InteractingShootingTargetEventArgs"/> instance.</param>
-        // [PluginEvent(ServerEventType.PlayerInteractShootingTarget)]
-        // TODO: Can't be implemented right now. No ShootingTarget argument.
         public static void OnInteractingShootingTarget(InteractingShootingTargetEventArgs ev) => InteractingShootingTarget.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> damages a shooting target.
         /// </summary>
         /// <param name="ev">The <see cref="DamagingShootingTargetEventArgs"/> instance.</param>
-        // [PluginEvent(ServerEventType.PlayerDamagedShootingTarget)]
-        // TODO: Can't be implemented right now. Missing arguments like distance and hitpoint.
         public static void OnDamagingShootingTarget(DamagingShootingTargetEventArgs ev) => DamagingShootingTarget.InvokeSafely(ev);
 
         /// <summary>

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -1026,7 +1026,6 @@ namespace Exiled.Events.Handlers
         /// Called before destroying a <see cref="API.Features.Player"/>.
         /// </summary>
         /// <param name="player"><inheritdoc cref="DestroyingEventArgs.Player"/></param>
-        [PluginEvent(ServerEventType.PlayerLeft)]
         public void OnDestroying(DestroyingEventArgs ev) => Destroying.InvokeSafely(ev);
     }
 }

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -907,7 +907,6 @@ namespace Exiled.Events.Handlers
         /// <param name="window"><inheritdoc cref="DamagingWindowEventArgs.Window"/></param>
         /// <param name="handler"><inheritdoc cref="DamagingWindowEventArgs.Handler"/></param>
         /// <param name="damageAmount">The damage inflicted to the window.</param>
-        // [PluginEvent(ServerEventType.PlayerDamagedWindow)]
         public void OnPlayerDamageWindow(DamagingWindowEventArgs ev) => PlayerDamageWindow.InvokeSafely(ev);
 
         /// <summary>

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -335,6 +335,11 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ProcessingHotkeyEventArgs> ProcessingHotkey;
 
         /// <summary>
+        /// Invoked before dropping ammo.
+        /// </summary>
+        public static event CustomEventHandler<DroppingAmmoEventArgs> DroppingAmmo;
+
+        /// <summary>
         /// Invoked before a <see cref="API.Features.Player"/> interacts with a shooting target.
         /// </summary>
         public static event CustomEventHandler<InteractingShootingTargetEventArgs> InteractingShootingTarget;

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -21,11 +21,9 @@ namespace Exiled.Events.Handlers
     using PluginAPI.Core.Attributes;
     using PluginAPI.Enums;
     using PluginAPI.Events;
+
     using static Events;
 
-#pragma warning disable SA1615
-#pragma warning disable SA1611
-#pragma warning disable SA1204
 #pragma warning disable IDE0079
 #pragma warning disable IDE0060
 
@@ -872,6 +870,102 @@ namespace Exiled.Events.Handlers
         public static void OnExitingEnvironmentalHazard(ExitingEnvironmentalHazardEventArgs ev) => ExitingEnvironmentalHazard.InvokeSafely(ev);
 
         /// <summary>
+        /// Called before a <see cref="API.Features.Player"/> damage a window.
+        /// </summary>
+        /// <param name="ev">The <see cref="DamagingWindowEventArgs"/> instance. </param>
+        public static void OnPlayerDamageWindow(DamagingWindowEventArgs ev) => PlayerDamageWindow.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a <see cref="API.Features.Player"/> unlocks a generator.
+        /// </summary>
+        /// <param name="ev">The <see cref="UnlockingGeneratorEventArgs"/> instance. </param>
+        public static void OnUnlockingGenerator(UnlockingGeneratorEventArgs ev) => UnlockingGenerator.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a <see cref="API.Features.Player"/> opens a generator.
+        /// </summary>
+        /// <param name="ev">The <see cref="OpeningGeneratorEventArgs"/> instance. </param>
+        public static void OnOpeningGenerator(OpeningGeneratorEventArgs ev) => OpeningGenerator.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a <see cref="API.Features.Player"/> closes a generator.
+        /// </summary>
+        /// <param name="ev">The <see cref="ClosingGeneratorEventArgs"/> instance. </param>
+        public static void OnClosingGenerator(ClosingGeneratorEventArgs ev) => ClosingGenerator.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a <see cref="API.Features.Player"/> turns on the generator by switching lever.
+        /// </summary>
+        /// <param name="ev">The <see cref="ActivatingGeneratorEventArgs"/> instance. </param>
+        public static void OnActivatingGenerator(ActivatingGeneratorEventArgs ev) => ActivatingGenerator.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a <see cref="API.Features.Player"/> turns off the generator by switching lever.
+        /// </summary>
+        /// <param name="ev">The <see cref="StoppingGeneratorEventArgs"/> instance. </param>
+        public static void OnStoppingGenerator(StoppingGeneratorEventArgs ev) => StoppingGenerator.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a <see cref="API.Features.Player"/> interacts with a door.
+        /// </summary>
+        /// <param name="ev">The <see cref="InteractingDoorEventArgs"/> instance. </param>
+        public static void OnInteractingDoor(InteractingDoorEventArgs ev) => InteractingDoor.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before dropping ammo.
+        /// </summary>
+        /// <param name="ev">The <see cref="DroppingAmmoEventArgs"/> instance. </param>
+        public static void OnDroppingAmmo(DroppingAmmoEventArgs ev) => DroppingAmmo.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before muting a user.
+        /// </summary>
+        /// <param name="ev">The <see cref="IssuingMuteEventArgs"/> instance. </param>
+        public static void OnIssuingMute(IssuingMuteEventArgs ev) => IssuingMute.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before unmuting a user.
+        /// </summary>
+        /// <param name="ev">The <see cref="RevokingMuteEventArgs"/> instance. </param>
+        public static void OnRevokingMute(RevokingMuteEventArgs ev) => RevokingMute.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a user's radio preset is changed.
+        /// </summary>
+        /// <param name="ev">The <see cref="ChangingRadioPresetEventArgs"/> instance. </param>
+        public static void OnChangingRadioPreset(ChangingRadioPresetEventArgs ev) => ChangingRadioPreset.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before hurting a player.
+        /// </summary>
+        /// <param name="ev">The <see cref="HurtingEventArgs"/> instance. </param>
+        public static void OnHurting(HurtingEventArgs ev) => Hurting.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a <see cref="API.Features.Player"/> dies.
+        /// </summary>
+        /// <param name="ev">The <see cref="DyingEventArgs"/> instance. </param>
+        public static void OnDying(DyingEventArgs ev) => Dying.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called after a <see cref="API.Features.Player"/> has joined the server.
+        /// </summary>
+        /// <param name="ev">The <see cref="JoinedEventArgs"/> instance. </param>
+        public static void OnJoined(JoinedEventArgs ev) => Joined.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called after a <see cref="API.Features.Player"/> has been verified.
+        /// </summary>
+        /// <param name="ev">The <see cref="VerifiedEventArgs"/> instance. </param>
+        public static void OnVerified(VerifiedEventArgs ev) => Verified.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before destroying a <see cref="API.Features.Player"/>.
+        /// </summary>
+        /// <param name="ev">The <see cref="DestroyingEventArgs"/> instance. </param>
+        public static void OnDestroying(DestroyingEventArgs ev) => Destroying.InvokeSafely(ev);
+
+        /// <summary>
         /// Called before pre-authenticating a <see cref="API.Features.Player"/>.
         /// </summary>
         /// <param name="userId"><inheritdoc cref="PreAuthenticatingEventArgs.UserId"/></param>
@@ -899,133 +993,5 @@ namespace Exiled.Events.Handlers
 
             return ev.CachedPreauthData;
         }
-
-        /// <summary>
-        /// Called before a <see cref="API.Features.Player"/> damage a window.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="DamagingWindowEventArgs.Player"/></param>
-        /// <param name="window"><inheritdoc cref="DamagingWindowEventArgs.Window"/></param>
-        /// <param name="handler"><inheritdoc cref="DamagingWindowEventArgs.Handler"/></param>
-        /// <param name="damageAmount">The damage inflicted to the window.</param>
-        public void OnPlayerDamageWindow(DamagingWindowEventArgs ev) => PlayerDamageWindow.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before a <see cref="API.Features.Player"/> unlocks a generator.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="UnlockingGeneratorEventArgs.Player"/></param>
-        /// <param name="generator"><inheritdoc cref="UnlockingGeneratorEventArgs.Generator"/></param>
-        /// <returns><inheritdoc cref="UnlockingGeneratorEventArgs.IsAllowed"/></returns>
-        public bool OnUnlockingGenerator(UnlockingGeneratorEventArgs ev) => UnlockingGenerator.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before a <see cref="API.Features.Player"/> opens a generator.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="OpeningGeneratorEventArgs.Player"/></param>
-        /// <param name="generator"><inheritdoc cref="OpeningGeneratorEventArgs.Generator"/></param>
-        /// <returns><inheritdoc cref="OpeningGeneratorEventArgs.IsAllowed"/></returns>
-        public bool OnOpeningGenerator(OpeningGeneratorEventArgs ev) => OpeningGenerator.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before a <see cref="API.Features.Player"/> closes a generator.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="OpeningGeneratorEventArgs.Player"/></param>
-        /// <param name="generator"><inheritdoc cref="OpeningGeneratorEventArgs.Generator"/></param>
-        /// <returns><inheritdoc cref="OpeningGeneratorEventArgs.IsAllowed"/></returns>
-        public bool OnClosingGenerator(ClosingGeneratorEventArgs ev) => ClosingGenerator.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before a <see cref="API.Features.Player"/> turns on the generator by switching lever.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="ActivatingGeneratorEventArgs.Player"/></param>
-        /// <param name="generator"><inheritdoc cref="ActivatingGeneratorEventArgs.Generator"/></param>
-        /// <returns><inheritdoc cref="ActivatingGeneratorEventArgs.IsAllowed"/></returns>
-        public bool OnActivatingGenerator(ActivatingGeneratorEventArgs ev) => ActivatingGenerator.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before a <see cref="API.Features.Player"/> turns off the generator by switching lever.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="ActivatingGeneratorEventArgs.Player"/></param>
-        /// <param name="generator"><inheritdoc cref="ActivatingGeneratorEventArgs.Generator"/></param>
-        /// <returns><inheritdoc cref="ActivatingGeneratorEventArgs.IsAllowed"/></returns>
-        public bool OnStoppingGenerator(StoppingGeneratorEventArgs ev) => StoppingGenerator.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before a <see cref="API.Features.Player"/> interacts with a door.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="InteractingDoorEventArgs.Player"/></param>
-        /// <param name="doorVariant"><inheritdoc cref="InteractingDoorEventArgs.Door"/></param>
-        /// <param name="canOpen">Indicates whether the door can open or not.</param>
-        /// <returns><inheritdoc cref="InteractingDoorEventArgs.IsAllowed"/></returns>
-        public bool OnInteractingDoor(InteractingDoorEventArgs ev) => InteractingDoor.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before dropping ammo.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="DroppingAmmoEventArgs.Player"/></param>
-        /// <param name="item"><inheritdoc cref="DroppingAmmoEventArgs.AmmoType"/></param>
-        /// <param name="amount"><inheritdoc cref="DroppingAmmoEventArgs.Amount"/></param>
-        /// <returns><inheritdoc cref="DroppingAmmoEventArgs.IsAllowed"/></returns>
-        public bool OnDroppingAmmo(DroppingAmmoEventArgs ev) => DroppingAmmo.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before muting a user.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="IssuingMuteEventArgs.Player"/></param>
-        /// <param name="isIntercom"><inheritdoc cref="IssuingMuteEventArgs.IsIntercom"/></param>
-        /// <returns><inheritdoc cref="IssuingMuteEventArgs.IsAllowed"/></returns>
-        public bool OnIssuingMute(IssuingMuteEventArgs ev) => IssuingMute.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before unmuting a user.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="IssuingMuteEventArgs.Player"/></param>
-        /// <param name="isIntercom"><inheritdoc cref="IssuingMuteEventArgs.IsIntercom"/></param>
-        /// <returns><inheritdoc cref="IssuingMuteEventArgs.IsAllowed"/></returns>
-        public bool OnRevokingMute(RevokingMuteEventArgs ev) => RevokingMute.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before a user's radio preset is changed.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="ChangingRadioPresetEventArgs.Player"/></param>
-        /// <param name="radio">The <see cref="RadioItem"/> instance.</param>
-        /// <param name="range"><inheritdoc cref="ChangingRadioPresetEventArgs.NewValue"/></param>
-        /// <returns><inheritdoc cref="ChangingRadioPresetEventArgs.IsAllowed"/></returns>
-        public bool OnChangingRadioPreset(ChangingRadioPresetEventArgs ev) => ChangingRadioPreset.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before hurting a player.
-        /// </summary>
-        /// <param name="target"><inheritdoc cref="HurtingEventArgs.Attacker"/></param>
-        /// <param name="attacker"><inheritdoc cref="HurtingEventArgs.Player"/></param>
-        /// <param name="damageHandler"><inheritdoc cref="HurtingEventArgs.DamageHandler"/></param>
-        /// <returns><inheritdoc cref="HurtingEventArgs.IsAllowed"/></returns>
-        public bool OnHurting(HurtingEventArgs ev) => Hurting.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before a <see cref="API.Features.Player"/> dies.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="DyingEventArgs.Player"/></param>
-        /// <param name="attacker"><inheritdoc cref="DyingEventArgs.Attacker"/></param>
-        /// <param name="damageHandler"><inheritdoc cref="DyingEventArgs.DamageHandler"/></param>
-        /// <returns><inheritdoc cref="DyingEventArgs.IsAllowed"/></returns>
-        public bool OnDying(DyingEventArgs ev) => Dying.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called after a <see cref="API.Features.Player"/> has joined the server.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="JoinedEventArgs.Player"/></param>
-        public void OnJoined(JoinedEventArgs ev) => Joined.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called after a <see cref="API.Features.Player"/> has been verified.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="VerifiedEventArgs.Player"/></param>
-        public void OnVerified(VerifiedEventArgs ev) => Verified.InvokeSafely(ev);
-
-        /// <summary>
-        /// Called before destroying a <see cref="API.Features.Player"/>.
-        /// </summary>
-        /// <param name="player"><inheritdoc cref="DestroyingEventArgs.Player"/></param>
-        public void OnDestroying(DestroyingEventArgs ev) => Destroying.InvokeSafely(ev);
     }
 }

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -21,9 +21,9 @@ namespace Exiled.Events.Handlers
     using PluginAPI.Core.Attributes;
     using PluginAPI.Enums;
     using PluginAPI.Events;
-
     using static Events;
-#pragma warning disable SA1615//TODO
+
+#pragma warning disable SA1615
 #pragma warning disable SA1611
 #pragma warning disable SA1204
 #pragma warning disable IDE0079
@@ -919,9 +919,8 @@ namespace Exiled.Events.Handlers
         /// <param name="window"><inheritdoc cref="DamagingWindowEventArgs.Window"/></param>
         /// <param name="handler"><inheritdoc cref="DamagingWindowEventArgs.Handler"/></param>
         /// <param name="damageAmount">The damage inflicted to the window.</param>
-        [PluginEvent(ServerEventType.PlayerDamagedWindow)]
-        public void OnPlayerDamageWindow(PluginAPI.Core.Player player, BreakableWindow window, PlayerStatsSystem.DamageHandlerBase handler, float damageAmount) =>
-            PlayerDamageWindow.InvokeSafely(new DamagingWindowEventArgs(window, damageAmount, handler));
+        // [PluginEvent(ServerEventType.PlayerDamagedWindow)]
+        public void OnPlayerDamageWindow(DamagingWindowEventArgs ev) => PlayerDamageWindow.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> unlocks a generator.
@@ -929,16 +928,7 @@ namespace Exiled.Events.Handlers
         /// <param name="player"><inheritdoc cref="UnlockingGeneratorEventArgs.Player"/></param>
         /// <param name="generator"><inheritdoc cref="UnlockingGeneratorEventArgs.Generator"/></param>
         /// <returns><inheritdoc cref="UnlockingGeneratorEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerUnlockGenerator)]
-        public bool OnUnlockingGenerator(PluginAPI.Core.Player player, Scp079Generator generator)
-        {
-            UnlockingGeneratorEventArgs ev = new(player, generator);
-
-            if (!UnlockingGenerator.InvokeSafely(ev))
-                ev.Generator.DenyUnlockAndResetCooldown();
-
-            return ev.IsAllowed;
-        }
+        public bool OnUnlockingGenerator(UnlockingGeneratorEventArgs ev) => UnlockingGenerator.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> opens a generator.
@@ -946,16 +936,7 @@ namespace Exiled.Events.Handlers
         /// <param name="player"><inheritdoc cref="OpeningGeneratorEventArgs.Player"/></param>
         /// <param name="generator"><inheritdoc cref="OpeningGeneratorEventArgs.Generator"/></param>
         /// <returns><inheritdoc cref="OpeningGeneratorEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerOpenGenerator)]
-        public bool OnOpeningGenerator(PluginAPI.Core.Player player, Scp079Generator generator)
-        {
-            OpeningGeneratorEventArgs ev = new(player, generator);
-
-            if (!OpeningGenerator.InvokeSafely(ev))
-                ev.Generator.DenyUnlockAndResetCooldown();
-
-            return ev.IsAllowed;
-        }
+        public bool OnOpeningGenerator(OpeningGeneratorEventArgs ev) => OpeningGenerator.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> closes a generator.
@@ -963,16 +944,7 @@ namespace Exiled.Events.Handlers
         /// <param name="player"><inheritdoc cref="OpeningGeneratorEventArgs.Player"/></param>
         /// <param name="generator"><inheritdoc cref="OpeningGeneratorEventArgs.Generator"/></param>
         /// <returns><inheritdoc cref="OpeningGeneratorEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerCloseGenerator)]
-        public bool OnClosingGenerator(PluginAPI.Core.Player player, Scp079Generator generator)
-        {
-            ClosingGeneratorEventArgs ev = new(player, generator);
-
-            if (!ClosingGenerator.InvokeSafely(ev))
-                ev.Generator.DenyUnlockAndResetCooldown();
-
-            return ev.IsAllowed;
-        }
+        public bool OnClosingGenerator(ClosingGeneratorEventArgs ev) => ClosingGenerator.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> turns on the generator by switching lever.
@@ -980,16 +952,7 @@ namespace Exiled.Events.Handlers
         /// <param name="player"><inheritdoc cref="ActivatingGeneratorEventArgs.Player"/></param>
         /// <param name="generator"><inheritdoc cref="ActivatingGeneratorEventArgs.Generator"/></param>
         /// <returns><inheritdoc cref="ActivatingGeneratorEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerActivateGenerator)]
-        public bool OnActivatingGenerator(PluginAPI.Core.Player player, Scp079Generator generator)
-        {
-            ActivatingGeneratorEventArgs ev = new(player, generator);
-
-            if (!ActivatingGenerator.InvokeSafely(ev))
-                ev.Generator.DenyUnlockAndResetCooldown();
-
-            return ev.IsAllowed;
-        }
+        public bool OnActivatingGenerator(ActivatingGeneratorEventArgs ev) => ActivatingGenerator.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> turns off the generator by switching lever.
@@ -997,16 +960,7 @@ namespace Exiled.Events.Handlers
         /// <param name="player"><inheritdoc cref="ActivatingGeneratorEventArgs.Player"/></param>
         /// <param name="generator"><inheritdoc cref="ActivatingGeneratorEventArgs.Generator"/></param>
         /// <returns><inheritdoc cref="ActivatingGeneratorEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerDeactivatedGenerator)]
-        public bool OnStoppingGenerator(PluginAPI.Core.Player player, Scp079Generator generator)
-        {
-            StoppingGeneratorEventArgs ev = new(player, generator);
-
-            if (!StoppingGenerator.InvokeSafely(ev))
-                ev.Generator.DenyUnlockAndResetCooldown();
-
-            return ev.IsAllowed;
-        }
+        public bool OnStoppingGenerator(StoppingGeneratorEventArgs ev) => StoppingGenerator.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> interacts with a door.
@@ -1015,10 +969,7 @@ namespace Exiled.Events.Handlers
         /// <param name="doorVariant"><inheritdoc cref="InteractingDoorEventArgs.Door"/></param>
         /// <param name="canOpen">Indicates whether the door can open or not.</param>
         /// <returns><inheritdoc cref="InteractingDoorEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerInteractDoor)]
-
-        // TODO: NWAPI supports skipping permission check, so player can change door's TargetStatus even if it doesn't met the keycard permissions. EXILED should implement that too.
-        public bool OnInteractingDoor(PluginAPI.Core.Player player, DoorVariant doorVariant, bool canOpen) => InteractingDoor.InvokeSafely(new(player, doorVariant));
+        public bool OnInteractingDoor(InteractingDoorEventArgs ev) => InteractingDoor.InvokeSafely(ev);
 
         /// <summary>
         /// Called before dropping ammo.
@@ -1027,9 +978,7 @@ namespace Exiled.Events.Handlers
         /// <param name="item"><inheritdoc cref="DroppingAmmoEventArgs.AmmoType"/></param>
         /// <param name="amount"><inheritdoc cref="DroppingAmmoEventArgs.Amount"/></param>
         /// <returns><inheritdoc cref="DroppingAmmoEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerDropAmmo)]
-        public bool OnDroppingAmmo(PluginAPI.Core.Player player, ItemType item, int amount)
-            => DroppingAmmo.InvokeSafely(new(player, item.GetAmmoType(), (ushort)amount));
+        public bool OnDroppingAmmo(DroppingAmmoEventArgs ev) => DroppingAmmo.InvokeSafely(ev);
 
         /// <summary>
         /// Called before muting a user.
@@ -1037,8 +986,7 @@ namespace Exiled.Events.Handlers
         /// <param name="player"><inheritdoc cref="IssuingMuteEventArgs.Player"/></param>
         /// <param name="isIntercom"><inheritdoc cref="IssuingMuteEventArgs.IsIntercom"/></param>
         /// <returns><inheritdoc cref="IssuingMuteEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerMuted)]
-        public bool OnIssuingMute(PluginAPI.Core.Player player, bool isIntercom) => IssuingMute.InvokeSafely(new(player, isIntercom));
+        public bool OnIssuingMute(IssuingMuteEventArgs ev) => IssuingMute.InvokeSafely(ev);
 
         /// <summary>
         /// Called before unmuting a user.
@@ -1046,8 +994,7 @@ namespace Exiled.Events.Handlers
         /// <param name="player"><inheritdoc cref="IssuingMuteEventArgs.Player"/></param>
         /// <param name="isIntercom"><inheritdoc cref="IssuingMuteEventArgs.IsIntercom"/></param>
         /// <returns><inheritdoc cref="IssuingMuteEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerUnmuted)]
-        public bool OnRevokingMute(PluginAPI.Core.Player player, bool isIntercom) => RevokingMute.InvokeSafely(new(player, isIntercom));
+        public bool OnRevokingMute(RevokingMuteEventArgs ev) => RevokingMute.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a user's radio preset is changed.
@@ -1056,9 +1003,7 @@ namespace Exiled.Events.Handlers
         /// <param name="radio">The <see cref="RadioItem"/> instance.</param>
         /// <param name="range"><inheritdoc cref="ChangingRadioPresetEventArgs.NewValue"/></param>
         /// <returns><inheritdoc cref="ChangingRadioPresetEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerChangeRadioRange)]
-        public bool OnChangingRadioPreset(PluginAPI.Core.Player player, RadioItem radio, byte range)
-            => ChangingRadioPreset.InvokeSafely(new(player, radio.RangeLevel, (RadioMessages.RadioRangeLevel)range));
+        public bool OnChangingRadioPreset(ChangingRadioPresetEventArgs ev) => ChangingRadioPreset.InvokeSafely(ev);
 
         /// <summary>
         /// Called before hurting a player.
@@ -1067,14 +1012,7 @@ namespace Exiled.Events.Handlers
         /// <param name="attacker"><inheritdoc cref="HurtingEventArgs.Player"/></param>
         /// <param name="damageHandler"><inheritdoc cref="HurtingEventArgs.DamageHandler"/></param>
         /// <returns><inheritdoc cref="HurtingEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerDamage)]
-        public bool OnHurting(PluginAPI.Core.Player target, PluginAPI.Core.Player attacker, DamageHandlerBase damageHandler)
-        {
-            if (damageHandler is RecontainmentDamageHandler && target.Role == RoleTypeId.Scp079)
-                Scp079.OnRecontained(new RecontainedEventArgs(target));
-
-            return Hurting.InvokeSafely(new(target, damageHandler));
-        }
+        public bool OnHurting(HurtingEventArgs ev) => Hurting.InvokeSafely(ev);
 
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> dies.
@@ -1083,66 +1021,25 @@ namespace Exiled.Events.Handlers
         /// <param name="attacker"><inheritdoc cref="DyingEventArgs.Attacker"/></param>
         /// <param name="damageHandler"><inheritdoc cref="DyingEventArgs.DamageHandler"/></param>
         /// <returns><inheritdoc cref="DyingEventArgs.IsAllowed"/></returns>
-        [PluginEvent(ServerEventType.PlayerDeath)]
-        public bool OnDying(PluginAPI.Core.Player player, PluginAPI.Core.Player attacker, PlayerStatsSystem.DamageHandlerBase damageHandler)
-            => Dying.InvokeSafely(new(player, damageHandler));
+        public bool OnDying(DyingEventArgs ev) => Dying.InvokeSafely(ev);
 
         /// <summary>
         /// Called after a <see cref="API.Features.Player"/> has joined the server.
         /// </summary>
         /// <param name="player"><inheritdoc cref="JoinedEventArgs.Player"/></param>
-        [PluginEvent(ServerEventType.PlayerJoined)]
-        public void OnJoined(PluginAPI.Core.Player player)
-        {
-            API.Features.Player exiledPlayer = new(player.ReferenceHub);
-            API.Features.Player.UnverifiedPlayers.Add(player.ReferenceHub, exiledPlayer);
-
-            Joined.InvokeSafely(new(exiledPlayer));
-        }
+        public void OnJoined(JoinedEventArgs ev) => Joined.InvokeSafely(ev);
 
         /// <summary>
         /// Called after a <see cref="API.Features.Player"/> has been verified.
         /// </summary>
         /// <param name="player"><inheritdoc cref="VerifiedEventArgs.Player"/></param>
-        [PluginEvent(ServerEventType.PlayerJoined)]
-        public void OnVerified(PluginAPI.Core.Player player)
-        {
-            if (!API.Features.Player.UnverifiedPlayers.TryGetValue(player.ReferenceHub, out API.Features.Player exiledPlayer))
-            {
-                Log.Error($"Player {player.Nickname} is not verified. This error should never appear.");
-                return;
-            }
-
-            API.Features.Player.Dictionary.Add(player.ReferenceHub.gameObject, exiledPlayer);
-
-            exiledPlayer.IsVerified = true;
-            exiledPlayer.RawUserId = exiledPlayer.UserId.GetRawUserId();
-
-            Log.SendRaw($"Player {exiledPlayer.Nickname} ({exiledPlayer.UserId}) ({exiledPlayer.Id}) connected with the IP: {exiledPlayer.IPAddress}", System.ConsoleColor.Green);
-
-            Verified.InvokeSafely(new(exiledPlayer));
-        }
+        public void OnVerified(VerifiedEventArgs ev) => Verified.InvokeSafely(ev);
 
         /// <summary>
         /// Called before destroying a <see cref="API.Features.Player"/>.
         /// </summary>
         /// <param name="player"><inheritdoc cref="DestroyingEventArgs.Player"/></param>
         [PluginEvent(ServerEventType.PlayerLeft)]
-        public void OnDestroying(PluginAPI.Core.Player player)
-        {
-            API.Features.Player exiledPlayer = player;
-
-            if (exiledPlayer is not null)
-            {
-                Destroying.InvokeSafely(new(exiledPlayer));
-
-                API.Features.Player.Dictionary.Remove(exiledPlayer.GameObject);
-                API.Features.Player.UnverifiedPlayers.Remove(exiledPlayer.ReferenceHub);
-                API.Features.Player.IdsCache.Remove(exiledPlayer.Id);
-
-                if (exiledPlayer.UserId != null)
-                    API.Features.Player.UserIdsCache.Remove(player.UserId);
-            }
-        }
+        public void OnDestroying(DestroyingEventArgs ev) => Destroying.InvokeSafely(ev);
     }
 }

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -711,7 +711,7 @@ namespace Exiled.Events.Handlers
         /// <summary>
         /// Called before a <see cref="API.Features.Player"/> MicroHID state is changed.
         /// </summary>
-        /// <param name="ev">The <see cref="ChangingRadioPresetEventArgs"/> instance.</param>
+        /// <param name="ev">The <see cref="ChangingMicroHIDStateEventArgs"/> instance.</param>
         public static void OnChangingMicroHIDState(ChangingMicroHIDStateEventArgs ev) => ChangingMicroHIDState.InvokeSafely(ev);
 
         /// <summary>

--- a/Exiled.Events/Patches/Events/Player/ChangingRadioPreset.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRadioPreset.cs
@@ -1,0 +1,91 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingRadioPreset.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs.Player;
+
+    using HarmonyLib;
+    using InventorySystem.Items;
+    using InventorySystem.Items.Radio;
+    using NorthwoodLib.Pools;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    ///     Patches <see cref="RadioItem.ServerProcessCmd(RadioMessages.RadioCommand)" />.
+    ///     Adds the <see cref="Handlers.Player.ChangingRadioPreset" /> event.
+    /// </summary>
+    [HarmonyPatch(typeof(RadioItem), nameof(RadioItem.ServerProcessCmd))]
+    internal static class ChangingRadioPreset
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            Label returnLabel = generator.DefineLabel();
+
+            LocalBuilder ev = generator.DeclareLocal(typeof(ChangingRadioPresetEventArgs));
+
+            const int offset = 0;
+            int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ldc_I4_S) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // Player.Get(base.Owner)
+                    new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
+                    new(OpCodes.Call, PropertyGetter(typeof(ItemBase), nameof(ItemBase.Owner))),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
+
+                    // (RadioRangeLevel)this._rangeId
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldfld, Field(typeof(RadioItem), nameof(RadioItem._rangeId))),
+                    new(OpCodes.Conv_I1),
+
+                    // (RadioRangeLevel)b
+                    new(OpCodes.Ldloc_0),
+                    new(OpCodes.Conv_I1),
+
+                    // true
+                    new(OpCodes.Ldc_I4_1),
+
+                    // ChangingRadioPresetEventArgs ev = new(Player, byte, byte, true)
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ChangingRadioPresetEventArgs))[0]),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc_S, ev.LocalIndex),
+
+                    // Handlers.Player.OnChangingRadioPreset(ev)
+                    new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnChangingRadioPreset))),
+
+                    // if (!ev.IsAllowed)
+                    //     return;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(ChangingRadioPresetEventArgs), nameof(ChangingRadioPresetEventArgs.IsAllowed))),
+                    new(OpCodes.Brfalse_S, returnLabel),
+
+                    // b = (byte)ev.NewValue
+                    new(OpCodes.Ldloc_S, ev.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(ChangingRadioPresetEventArgs), nameof(ChangingRadioPresetEventArgs.NewValue))),
+                    new(OpCodes.Conv_U1),
+                    new(OpCodes.Stloc_0),
+                });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/DamagingWindow.cs
+++ b/Exiled.Events/Patches/Events/Player/DamagingWindow.cs
@@ -1,0 +1,82 @@
+// -----------------------------------------------------------------------
+// <copyright file="DamagingWindow.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using API.Features.DamageHandlers;
+    using Exiled.Events.EventArgs.Player;
+    using Handlers;
+    using HarmonyLib;
+    using NorthwoodLib.Pools;
+    using UnityEngine;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    ///     Patch the <see cref="BreakableWindow.Damage(float, PlayerStatsSystem.DamageHandlerBase, Vector3)" />.
+    ///     Adds the <see cref="Player.PlayerDamageWindow" /> event.
+    /// </summary>
+    [HarmonyPatch(typeof(BreakableWindow), nameof(BreakableWindow.Damage))]
+    internal static class DamagingWindow
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            LocalBuilder ev = generator.DeclareLocal(typeof(DamagingWindowEventArgs));
+
+            Label ret = generator.DefineLabel();
+
+            int offset = 0;
+            int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Ldc_I4_S) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // this
+                    new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
+
+                    // damage
+                    new(OpCodes.Ldarg_1),
+
+                    // handler
+                    new(OpCodes.Ldarg_2),
+
+                    // DamagingWindowEventArgs ev = new(player, this, damage, handler);
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(DamagingWindowEventArgs))[0]),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc, ev.LocalIndex),
+
+                    // Handlers.Player.OnPlayerDamageWindow(ev);
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnPlayerDamageWindow))),
+
+                    // if (!ev.IsAllowed)
+                    //    return;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(DamagingWindowEventArgs), nameof(DamagingWindowEventArgs.IsAllowed))),
+                    new(OpCodes.Brfalse, ret),
+
+                    // damage = ev.Handler.Damage;
+                    new(OpCodes.Ldloc, ev.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(DamagingWindowEventArgs), nameof(DamagingWindowEventArgs.Handler))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(CustomDamageHandler), nameof(CustomDamageHandler.Damage))),
+                    new(OpCodes.Starg_S, 1),
+                });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(ret);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/Destroying.cs
+++ b/Exiled.Events/Patches/Events/Player/Destroying.cs
@@ -1,0 +1,105 @@
+// -----------------------------------------------------------------------
+// <copyright file="Destroying.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+#pragma warning disable SA1600
+
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+    using System.Runtime.CompilerServices;
+
+    using API.Features;
+    using Exiled.Events.EventArgs.Player;
+
+    using HarmonyLib;
+
+    using NorthwoodLib.Pools;
+
+    using UnityEngine;
+
+    using static HarmonyLib.AccessTools;
+
+    [HarmonyPatch(typeof(ReferenceHub), nameof(ReferenceHub.OnDestroy))]
+    internal static class Destroying
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            Label continueLabel = generator.DefineLabel();
+
+            LocalBuilder player = generator.DeclareLocal(typeof(Player));
+
+            newInstructions[0].labels.Add(continueLabel);
+
+            newInstructions.InsertRange(
+                0,
+                new CodeInstruction[]
+                {
+                    // Player player = Player.Get(this)
+                    //
+                    // if (player == null)
+                    //    goto continueLabel;
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc_S, player.LocalIndex),
+                    new(OpCodes.Ldnull),
+                    new(OpCodes.Ceq),
+                    new(OpCodes.Brtrue_S, continueLabel),
+
+                    // DestroyingEventArgs ev = new(Player)
+                    new(OpCodes.Ldloc_S, player.LocalIndex),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(DestroyingEventArgs))[0]),
+
+                    // Handlers.Player.OnDestroying(ev)
+                    new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnDestroying))),
+
+                    // Player.Dictionary.Remove(player.GameObject)
+                    new(OpCodes.Call, PropertyGetter(typeof(Player), nameof(Player.Dictionary))),
+                    new(OpCodes.Ldloc_S, player.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.GameObject))),
+                    new(OpCodes.Callvirt, Method(typeof(Dictionary<GameObject, Player>), nameof(Dictionary<GameObject, Player>.Remove), new[] { typeof(GameObject) })),
+                    new(OpCodes.Pop),
+
+                    // Player.UnverifiedPlayers.Remove(this)
+                    new(OpCodes.Call, PropertyGetter(typeof(Player), nameof(Player.UnverifiedPlayers))),
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Callvirt, Method(typeof(ConditionalWeakTable<ReferenceHub, Player>), nameof(ConditionalWeakTable<ReferenceHub, Player>.Remove), new[] { typeof(ReferenceHub) })),
+                    new(OpCodes.Pop),
+
+                    // Player.IdsCache.Remove(player.Id)
+                    new(OpCodes.Call, PropertyGetter(typeof(Player), nameof(Player.IdsCache))),
+                    new(OpCodes.Ldloc_S, player.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.Id))),
+                    new(OpCodes.Callvirt, Method(typeof(Dictionary<int, Player>), nameof(Dictionary<int, Player>.Remove), new[] { typeof(int) })),
+                    new(OpCodes.Pop),
+
+                    // if (player.UserId == null)
+                    //    goto continueLabel;
+                    new(OpCodes.Ldloc_S, player.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.UserId))),
+                    new(OpCodes.Ldnull),
+                    new(OpCodes.Ceq),
+                    new(OpCodes.Brtrue_S, continueLabel),
+
+                    // Player.UserIdsCache.Remove(player.UserId)
+                    new(OpCodes.Call, PropertyGetter(typeof(Player), nameof(Player.UserIdsCache))),
+                    new(OpCodes.Ldloc_S, player.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.UserId))),
+                    new(OpCodes.Callvirt, Method(typeof(Dictionary<string, Player>), nameof(Dictionary<string, Player>.Remove), new[] { typeof(string) })),
+                    new(OpCodes.Pop),
+                });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/DroppingAmmo.cs
+++ b/Exiled.Events/Patches/Events/Player/DroppingAmmo.cs
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------
+// <copyright file="DroppingAmmo.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using API.Features;
+    using Exiled.Events.EventArgs.Player;
+
+    using HarmonyLib;
+
+    using InventorySystem;
+
+    using NorthwoodLib.Pools;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    ///     Patches <see cref="Inventory.UserCode_CmdDropAmmo" />.
+    ///     Adds the <see cref="DroppingAmmo" /> event.
+    /// </summary>
+    [HarmonyPatch(typeof(Inventory), nameof(Inventory.UserCode_CmdDropAmmo))]
+    internal static class DroppingAmmo
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            Label returnLabel = generator.DefineLabel();
+
+            newInstructions.InsertRange(
+                0,
+                new CodeInstruction[]
+                {
+                    // Player.Get(ReferenceHub);
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldfld, Field(typeof(Inventory), nameof(Inventory._hub))),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
+
+                    // ammoType
+                    new(OpCodes.Ldarg_1),
+
+                    // amount
+                    new(OpCodes.Ldarg_2),
+
+                    // true
+                    new(OpCodes.Ldc_I4_1),
+
+                    // DroppingAmmoEventArgs ev = new(Player, AmmoType, ushort, bool)
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(DroppingAmmoEventArgs))[0]),
+                    new(OpCodes.Dup),
+
+                    // Player.OnDroppingAmmo(ev);
+                    new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnDroppingAmmo))),
+
+                    // if (!ev.IsAllowed)
+                    //    return;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(DroppingAmmoEventArgs), nameof(DroppingAmmoEventArgs.IsAllowed))),
+                    new(OpCodes.Brfalse_S, returnLabel),
+                });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/DyingAndDied.cs
+++ b/Exiled.Events/Patches/Events/Player/DyingAndDied.cs
@@ -49,7 +49,7 @@ namespace Exiled.Events.Patches.Events.Player
                     /*new(OpCodes.Dup),*/
                     new(OpCodes.Stloc_S, player.LocalIndex),
 
-                    /*// handler
+                    // handler
                     new(OpCodes.Ldarg_1),
 
                     // DyingEventArgs ev = new(Player, DamageHandlerBase)
@@ -68,7 +68,7 @@ namespace Exiled.Events.Patches.Events.Player
                     new(OpCodes.Ldloc_S, player.LocalIndex),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.Role))),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(Role), nameof(Role.Type))),
-                    new(OpCodes.Stloc, oldRole.LocalIndex),*/
+                    new(OpCodes.Stloc, oldRole.LocalIndex),
                 });
 
             newInstructions.InsertRange(

--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -1,0 +1,106 @@
+// -----------------------------------------------------------------------
+// <copyright file="Hurting.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features.Roles;
+    using Exiled.Events.EventArgs.Player;
+    using Exiled.Events.EventArgs.Scp079;
+    using Exiled.Events.Handlers;
+
+    using HarmonyLib;
+
+    using NorthwoodLib.Pools;
+
+    using PlayerStatsSystem;
+
+    using static HarmonyLib.AccessTools;
+
+    using Player = API.Features.Player;
+
+    /// <summary>
+    ///     Patches <see cref="PlayerStats.DealDamage(DamageHandlerBase)" />.
+    ///     Adds the <see cref="Handlers.Player.Hurting" /> event.
+    /// </summary>
+    [HarmonyPatch(typeof(PlayerStats), nameof(PlayerStats.DealDamage))]
+    internal static class Hurting
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            LocalBuilder player = generator.DeclareLocal(typeof(Player));
+            LocalBuilder ev = generator.DeclareLocal(typeof(HurtingEventArgs));
+
+            Label notRecontainment = generator.DefineLabel();
+            Label ret = generator.DefineLabel();
+
+            const int offset = 1;
+            int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ret) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // Player player = Player.Get(this._hub)
+                    new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
+                    new(OpCodes.Ldfld, Field(typeof(PlayerStats), nameof(PlayerStats._hub))),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
+                    new(OpCodes.Stloc, player.LocalIndex),
+
+                    // if (handler is RecontainmentDamageHandler)
+                    // {
+                    //    if (player.Role == RoleTypeId.Scp079)
+                    //    {
+                    //        Handlers.Scp079.OnRecontained(new RecontainedEventArgs(player));
+                    //        return;
+                    //    }
+                    // }
+                    new(OpCodes.Ldarg_1),
+                    new(OpCodes.Isinst, typeof(RecontainmentDamageHandler)),
+                    new(OpCodes.Brfalse, notRecontainment),
+
+                    new(OpCodes.Ldloc, player.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.Role))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(Role), nameof(Role.Type))),
+                    new(OpCodes.Ldc_I4_7),
+                    new(OpCodes.Ceq),
+                    new(OpCodes.Brfalse, notRecontainment),
+
+                    new(OpCodes.Ldloc, player.LocalIndex),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(RecontainedEventArgs))[0]),
+                    new(OpCodes.Call, Method(typeof(Scp079), nameof(Scp079.OnRecontained))),
+
+                    // HurtingEventArgs ev = new(player, handler)
+                    new CodeInstruction(OpCodes.Ldloc, player.LocalIndex).WithLabels(notRecontainment),
+                    new(OpCodes.Ldarg_1),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(HurtingEventArgs))[0]),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc, ev.LocalIndex),
+
+                    // Handlers.Player.OnHurting(ev);
+                    new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnHurting))),
+
+                    // if (!ev.IsAllowed)
+                    //    return;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(HurtingEventArgs), nameof(HurtingEventArgs.IsAllowed))),
+                    new(OpCodes.Brfalse, ret),
+                });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(ret);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/InteractingGenerator.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingGenerator.cs
@@ -1,0 +1,325 @@
+// -----------------------------------------------------------------------
+// <copyright file="InteractingGenerator.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Reflection.Emit;
+
+    using Exiled.Events.EventArgs.Player;
+    using Footprinting;
+    using Handlers;
+
+    using HarmonyLib;
+
+    using MapGeneration.Distributors;
+
+    using NorthwoodLib.Pools;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    /// Patches <see cref="Scp079Generator.ServerInteract(ReferenceHub, byte)"/>.
+    /// Adds the <see cref="Player.ActivatingGenerator"/>, <see cref="Player.ClosingGenerator"/>, <see cref="Player.OpeningGenerator"/>, <see cref="Player.UnlockingGenerator"/> and <see cref="Player.StoppingGenerator"/> events.
+    /// </summary>
+    [HarmonyPatch(typeof(Scp079Generator), nameof(Scp079Generator.ServerInteract))]
+    internal static class InteractingGenerator
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            LocalBuilder player = generator.DeclareLocal(typeof(API.Features.Player));
+
+            Label isOpening = generator.DefineLabel();
+            Label isActivating = generator.DefineLabel();
+            Label check = generator.DefineLabel();
+            Label check2 = generator.DefineLabel();
+            Label notAllowed = generator.DefineLabel();
+            Label skip = generator.DefineLabel();
+            Label @break = newInstructions.FindLast(instruction => instruction.IsLdarg(0)).labels[0];
+
+            int offset = 1;
+            int index = newInstructions.FindIndex(instruction => instruction.Calls(Method(typeof(Stopwatch), nameof(Stopwatch.Stop)))) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // Player player = Player.Get(ply)
+                    new CodeInstruction(OpCodes.Ldarg_1),
+                    new(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(ReferenceHub) })),
+                    new(OpCodes.Stloc_S, player.LocalIndex),
+                });
+
+            offset = 7;
+            index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Br) + offset;
+
+            // if (this.HasFlag(_flags, GeneratorFlags.Open))
+            // {
+            //     ClosingGeneratorEventArgs ev = new(player, this, true);
+            //
+            //     Player.OnClosingGenerator(ev);
+            //
+            //     if (!ev.IsAllowed)
+            //     {
+            //         this._targetCooldown = this._unlockCooldownTime;
+            //         this.RpcDenied();
+            //         break;
+            //     }
+            // }
+            // else
+            // {
+            //     OpeningGeneratorEventArgs ev = new(player, this, true);
+            //
+            //     Player.OnOpeningGenerator(ev);
+            //
+            //     if (!ev.IsAllowed)
+            //     {
+            //         this._targetCooldown = this._unlockCooldownTime;
+            //         this.RpcDenied();
+            //         break;
+            //     }
+            // }
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // player
+                    new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex),
+
+                    // this
+                    new(OpCodes.Ldarg_0),
+
+                    // true
+                    new(OpCodes.Ldc_I4_1),
+
+                    // if (!this.HasFlag(_flags, GeneratorFlags.Open))
+                    //    goto isOpening;
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldfld, Field(typeof(Scp079Generator), nameof(Scp079Generator._flags))),
+                    new(OpCodes.Ldc_I4_4), // GeneratorFlags.Open
+                    new(OpCodes.Callvirt, Method(typeof(Scp079Generator), nameof(Scp079Generator.HasFlag))),
+                    new(OpCodes.Brfalse_S, isOpening),
+
+                    // ClosingGeneratorEventArgs ev = new(Player, Scp079Generator, bool)
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ClosingGeneratorEventArgs))[0]),
+                    new(OpCodes.Dup),
+
+                    // Player.OnClosingGenerator(ev)
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnClosingGenerator))),
+
+                    // ev.IsAllowed
+                    //
+                    // goto check
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(ClosingGeneratorEventArgs), nameof(ClosingGeneratorEventArgs.IsAllowed))),
+                    new(OpCodes.Br_S, check),
+
+                    // OpeningGeneratorEventArgs ev = new(Player, Scp079Generator, bool)
+                    new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(OpeningGeneratorEventArgs))[0]).WithLabels(isOpening),
+                    new(OpCodes.Dup),
+
+                    // Player.OnOpeningGenerator(ev)
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnOpeningGenerator))),
+
+                    // loads ev.isAllowed
+                    //
+                    // if (ev.IsAllowed)
+                    //    goto skip;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(OpeningGeneratorEventArgs), nameof(OpeningGeneratorEventArgs.IsAllowed))),
+                    new CodeInstruction(OpCodes.Brtrue_S, skip).WithLabels(check),
+
+                    // notAllowed:
+                    //
+                    // this._targetCooldown = this._unlockCooldownTime;
+                    new CodeInstruction(OpCodes.Ldarg_0).WithLabels(notAllowed),
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldfld, Field(typeof(Scp079Generator), nameof(Scp079Generator._unlockCooldownTime))),
+                    new(OpCodes.Stfld, Field(typeof(Scp079Generator), nameof(Scp079Generator._targetCooldown))),
+
+                    // this.RpcDenied()
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Callvirt, Method(typeof(Scp079Generator), nameof(Scp079Generator.RpcDenied))),
+
+                    // goto @break
+                    new(OpCodes.Br_S, @break),
+
+                    // skip:
+                    new CodeInstruction(OpCodes.Nop).WithLabels(skip),
+                });
+
+            offset = -8;
+            index = newInstructions.FindIndex(
+                instruction => instruction.Calls(Method(typeof(Scp079Generator), nameof(Scp079Generator.ServerGrantTicketsConditionally)))) + offset;
+
+            // remove base game unlocking, we will unlock generator and grant tickets after UnlockingGeneratorEventArgs invokation and allowed check
+            newInstructions.RemoveRange(index, 9);
+
+            offset = -5;
+            index = newInstructions.FindIndex(instruction => instruction.Calls(Method(typeof(Scp079Generator), nameof(Scp079Generator.RpcDenied)))) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // player
+                    new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex).MoveLabelsFrom(newInstructions[index]),
+
+                    // this
+                    new(OpCodes.Ldarg_0),
+
+                    // true
+                    new(OpCodes.Ldc_I4_0),
+                });
+
+            index += 3;
+
+            // remove base game cooldown logic and RpcDenied (same as unlocking)
+            newInstructions.RemoveRange(index, 6);
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // UnlockingGeneratorEventArgs ev = new(Player, Scp079Generator, bool)
+                    new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(UnlockingGeneratorEventArgs))[0]),
+                    new(OpCodes.Dup),
+
+                    // Player.OnUnlockingGenerator(ev)
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnUnlockingGenerator))),
+
+                    // if (!ev.IsAllowed)
+                    //    goto notAllowed;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(UnlockingGeneratorEventArgs), nameof(UnlockingGeneratorEventArgs.IsAllowed))),
+                    new(OpCodes.Brfalse_S, notAllowed),
+
+                    // this.ServerSetFlag(GeneratorFlags.Unlocked, true)
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldc_I4_2), // GeneratorFlags.Unlocked
+                    new(OpCodes.Ldc_I4_1),
+                    new(OpCodes.Callvirt, Method(typeof(Scp079Generator), nameof(Scp079Generator.ServerSetFlag))),
+
+                    // this.ServerGrantTicketsConditionally(new Footprinting.Footprint(ply), 0.5f)
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldarg_1),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(Footprint))[0]),
+                    new(OpCodes.Ldc_R4, 0.5f),
+                    new(OpCodes.Call, Method(typeof(Scp079Generator), nameof(Scp079Generator.ServerGrantTicketsConditionally))),
+                });
+
+            offset = -5;
+            index = newInstructions.FindIndex(i => i.Calls(PropertySetter(typeof(Scp079Generator), nameof(Scp079Generator.Activating)))) + offset;
+
+            // if (this.Activating)
+            // {
+            //     StoppingGeneratorEventArgs ev = new(player, this, true);
+            //
+            //     Player.OnStoppingGenerator(ev);
+            //
+            //     if (!ev.IsAllowed)
+            //     {
+            //         this._targetCooldown = this._unlockCooldownTime;
+            //         this.RpcDenied();
+            //         break;
+            //     }
+            // }
+            // else
+            // {
+            //     ActivatingGeneratorEventArgs ev = new(player, this, true);
+            //
+            //     Player.OnActivatingGenerator(ev);
+            //
+            //     if (!ev.IsAllowed)
+            //     {
+            //         this._targetCooldown = this._unlockCooldownTime;
+            //         this.RpcDenied();
+            //         break;
+            //     }
+            // }
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // player
+                    new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex).MoveLabelsFrom(newInstructions[index]),
+
+                    // this
+                    new(OpCodes.Ldarg_0),
+
+                    // true
+                    new(OpCodes.Ldc_I4_1),
+
+                    // if (!this.Activating)
+                    //    goto isActivating;
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(Scp079Generator), nameof(Scp079Generator.Activating))),
+                    new(OpCodes.Brfalse_S, isActivating),
+
+                    // StoppingGeneratorEventArgs ev = new(Player, Scp079Generator, bool)
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(StoppingGeneratorEventArgs))[0]),
+                    new(OpCodes.Dup),
+
+                    // Player.OnStoppingGenerator(ev)
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnStoppingGenerator))),
+
+                    // ev.IsAllowed
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(StoppingGeneratorEventArgs), nameof(StoppingGeneratorEventArgs.IsAllowed))),
+                    new(OpCodes.Br_S, check2),
+
+                    // isActivating:
+                    //
+                    // ActivatingGeneratorEventArgs ev = new(Player, Scp079Generator, bool)
+                    new CodeInstruction(OpCodes.Newobj, GetDeclaredConstructors(typeof(ActivatingGeneratorEventArgs))[0]).WithLabels(isActivating),
+                    new(OpCodes.Dup),
+
+                    // Player.OnActivatingGenerator(ev)
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnActivatingGenerator))),
+
+                    // if (!ev.IsAllowed)
+                    //    goto notAllowed;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(ActivatingGeneratorEventArgs), nameof(ActivatingGeneratorEventArgs.IsAllowed))),
+                    new CodeInstruction(OpCodes.Brfalse_S, notAllowed).WithLabels(check2),
+                });
+
+            offset = 1;
+            index = newInstructions.FindLastIndex(i => i.opcode == OpCodes.Brfalse_S) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // player
+                    new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex),
+
+                    // this
+                    new(OpCodes.Ldarg_0),
+
+                    // true
+                    new(OpCodes.Ldc_I4_1),
+
+                    // StoppingGeneratorEventArgs ev = new(Player, Scp079Generator, bool)
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(StoppingGeneratorEventArgs))[0]),
+                    new(OpCodes.Dup),
+
+                    // Player.OnStoppingGenerator(ev)
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.OnStoppingGenerator))),
+
+                    // if (!ev.IsAllowed)
+                    //     return notAllowed;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(StoppingGeneratorEventArgs), nameof(StoppingGeneratorEventArgs.IsAllowed))),
+                    new(OpCodes.Brfalse_S, notAllowed),
+                });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/IssuingMute.cs
+++ b/Exiled.Events/Patches/Events/Player/IssuingMute.cs
@@ -1,0 +1,83 @@
+// -----------------------------------------------------------------------
+// <copyright file="IssuingMute.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs.Player;
+
+    using HarmonyLib;
+
+    using NorthwoodLib.Pools;
+    using VoiceChat;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    ///     Patch the <see cref="VoiceChatMutes.IssueLocalMute(string, bool)" />.
+    ///     Adds the <see cref="Handlers.Player.IssuingMute" /> event.
+    /// </summary>
+    [HarmonyPatch(typeof(VoiceChatMutes), nameof(VoiceChatMutes.IssueLocalMute))]
+    internal static class IssuingMute
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            Label retLabel = generator.DefineLabel();
+
+            LocalBuilder ev = generator.DeclareLocal(typeof(IssuingMuteEventArgs));
+
+            const int offset = 0;
+            int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ldsfld) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // Player.Get(userId)
+                    new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(string) })),
+
+                    // intercom
+                    new(OpCodes.Ldarg_1),
+
+                    // true
+                    new(OpCodes.Ldc_I4_1),
+
+                    // IssuingMuteEventArgs ev = new(Player, bool, bool)
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(IssuingMuteEventArgs))[0]),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc_S, ev.LocalIndex),
+
+                    // Handlers.Player.OnIssuingMute(ev)
+                    new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnIssuingMute))),
+
+                    // if (!ev.IsAllowed)
+                    //    return;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(IssuingMuteEventArgs), nameof(IssuingMuteEventArgs.IsAllowed))),
+                    new(OpCodes.Brfalse_S, retLabel),
+
+                    // intercom = ev.IsIntercom
+                    new(OpCodes.Ldloc_S, ev.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(IssuingMuteEventArgs), nameof(IssuingMuteEventArgs.IsIntercom))),
+                    new(OpCodes.Starg_S, 1),
+                });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(retLabel);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/Joined.cs
+++ b/Exiled.Events/Patches/Events/Player/Joined.cs
@@ -1,0 +1,116 @@
+// -----------------------------------------------------------------------
+// <copyright file="Joined.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+#pragma warning disable SA1600
+
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs.Player;
+    using Exiled.Loader.Features;
+
+    using HarmonyLib;
+
+    using NorthwoodLib.Pools;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    ///     Patches <see cref="ReferenceHub.Awake" />.
+    ///     Adds the <see cref="Handlers.Player.Joined" /> event.
+    /// </summary>
+    [HarmonyPatch(typeof(ReferenceHub), nameof(ReferenceHub.Awake))]
+    internal static class Joined
+    {
+        internal static void CallEvent(ReferenceHub hub, out Player player)
+        {
+            try
+            {
+#if DEBUG
+                Log.Debug("Creating new player object");
+#endif
+                player = new Player(hub);
+#if DEBUG
+                Log.Debug($"Object exists {player is not null}");
+                Log.Debug($"Creating player object for {hub.nicknameSync.Network_displayName}");
+#endif
+                Player.UnverifiedPlayers.Add(hub, player);
+
+                Handlers.Player.OnJoined(new JoinedEventArgs(player));
+            }
+            catch (Exception exception)
+            {
+                Log.Error($"{nameof(CallEvent)}: {exception}\n{exception.StackTrace}");
+                player = null;
+            }
+        }
+
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            Label ret = generator.DefineLabel();
+            Label serverNotFull = generator.DefineLabel();
+
+            LocalBuilder outPlayer = generator.DeclareLocal(typeof(Player));
+
+            newInstructions[newInstructions.Count - 1].WithLabels(ret);
+
+            newInstructions.InsertRange(
+                newInstructions.Count - 1,
+                new[]
+                {
+                    // if (this.isServer)
+                    //    goto continueLabel;
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.isServer))),
+                    new(OpCodes.Brtrue_S, ret),
+
+                    // if (ReferenceHub.HostHub == null)
+                    //    goto continueLabel;
+                    new(OpCodes.Call, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.HostHub))),
+                    new(OpCodes.Ldnull),
+                    new(OpCodes.Ceq),
+                    new(OpCodes.Brtrue_S, ret),
+
+                    // if (ReferenceHub.LocalHub == null)
+                    //    goto continueLabel;
+                    new(OpCodes.Call, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.LocalHub))),
+                    new(OpCodes.Ldnull),
+                    new(OpCodes.Ceq),
+                    new(OpCodes.Brtrue_S, ret),
+
+                    // if (ReferenceHub.AllHubs.Count < CustomNetworkManager.slots)
+                    //    goto serverNotFull;
+                    new(OpCodes.Call, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.AllHubs))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(HashSet<ReferenceHub>), nameof(HashSet<ReferenceHub>.Count))),
+                    new(OpCodes.Ldsfld, Field(typeof(CustomNetworkManager), nameof(CustomNetworkManager.slots))),
+                    new(OpCodes.Blt_S, serverNotFull),
+
+                    // MultiAdminFeatures.CallEvent(EventType.SERVER_FULL)
+                    new(OpCodes.Ldc_I4_4),
+                    new(OpCodes.Call, Method(typeof(MultiAdminFeatures), nameof(MultiAdminFeatures.CallEvent))),
+                    new(OpCodes.Pop),
+
+                    // serverNotFull:
+                    // CallEvent(this, out Player player)
+                    new CodeInstruction(OpCodes.Ldarg_0).WithLabels(serverNotFull),
+                    new(OpCodes.Ldloca_S, outPlayer),
+                    new(OpCodes.Call, Method(typeof(Joined), nameof(CallEvent))),
+                });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/RevokingMute.cs
+++ b/Exiled.Events/Patches/Events/Player/RevokingMute.cs
@@ -1,0 +1,83 @@
+// -----------------------------------------------------------------------
+// <copyright file="RevokingMute.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs.Player;
+
+    using HarmonyLib;
+
+    using NorthwoodLib.Pools;
+    using VoiceChat;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    ///     Patch the <see cref="VoiceChatMutes.RevokeLocalMute(string, bool)" />.
+    ///     Adds the <see cref="Handlers.Player.RevokingMute" /> event.
+    /// </summary>
+    [HarmonyPatch(typeof(VoiceChatMutes), nameof(VoiceChatMutes.RevokeLocalMute))]
+    internal static class RevokingMute
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            Label retLabel = generator.DefineLabel();
+
+            LocalBuilder ev = generator.DeclareLocal(typeof(IssuingMuteEventArgs));
+
+            const int offset = 0;
+            int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Ldsfld) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // Player.Get(userId)
+                    new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
+                    new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(string) })),
+
+                    // intercom
+                    new(OpCodes.Ldarg_1),
+
+                    // true
+                    new(OpCodes.Ldc_I4_1),
+
+                    // RevokingMuteEventArgs ev = new(Player, bool, bool)
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(RevokingMuteEventArgs))[0]),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc_S, ev.LocalIndex),
+
+                    // Handlers.Player.OnRevokingMute(ev)
+                    new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnRevokingMute))),
+
+                    // if (!ev.IsAllowed)
+                    //    return;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(RevokingMuteEventArgs), nameof(RevokingMuteEventArgs.IsAllowed))),
+                    new(OpCodes.Brfalse_S, retLabel),
+
+                    // intercom = ev.IsIntercom
+                    new(OpCodes.Ldloc_S, ev.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(RevokingMuteEventArgs), nameof(RevokingMuteEventArgs.IsIntercom))),
+                    new(OpCodes.Starg_S, 1),
+                });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(retLabel);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/Verified.cs
+++ b/Exiled.Events/Patches/Events/Player/Verified.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------
+// <copyright file="Verified.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Extensions;
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs.Player;
+
+    using HarmonyLib;
+
+    using NorthwoodLib.Pools;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    ///     Patches <see cref="ServerRoles.UserCode_CmdServerSignatureComplete" />.
+    ///     Adds the <see cref="Handlers.Player.Verified" /> event.
+    /// </summary>
+    [HarmonyPatch(typeof(ServerRoles), nameof(ServerRoles.UserCode_CmdServerSignatureComplete))]
+    internal static class Verified
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Shared.Rent(instructions);
+
+            Label callJoined = generator.DefineLabel();
+
+            LocalBuilder player = generator.DeclareLocal(typeof(Player));
+
+            const int offset = -2;
+            int index = newInstructions.FindIndex(instruction => instruction.Calls(Method(typeof(ServerRoles), nameof(ServerRoles.RefreshPermissions)))) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    new(OpCodes.Ldarg_0),
+                    new CodeInstruction(OpCodes.Call, Method(typeof(Verified), nameof(Verified.HandleCmdServerSignature))),
+                });
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Shared.Return(newInstructions);
+        }
+
+        private static void HandleCmdServerSignature(ServerRoles instance)
+        {
+            if (!Player.UnverifiedPlayers.TryGetValue(instance._hub, out Player player))
+                Joined.CallEvent(instance._hub, out player);
+
+            Player.Dictionary.Add(instance._hub.gameObject, player);
+
+            player.IsVerified = true;
+            player.RawUserId = player.UserId.GetRawUserId();
+
+            Log.SendRaw($"Player {player.Nickname} ({player.UserId}) ({player.Id}) connected with the IP: {player.IPAddress}", ConsoleColor.Green);
+
+            Handlers.Player.OnVerified(new VerifiedEventArgs(player));
+        }
+    }
+}


### PR DESCRIPTION
Due to issues that using NWAPI for EXILED created we decided to not rely on it and handle cancelable events ourselves.
Currently, only Preauth event won't be reverted as I think it works better then the previous one. It uses base-game methods and we don't write directly to NetworkWriter anymore.