### PR TITLE
Fixeeee

### DIFF
--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -44,6 +44,7 @@ namespace Exiled.API.Features
         {
             if (room != null)
                 DoorVariantToDoor.Add(door, this);
+
             Base = door;
             Room = room;
             Type = GetDoorType();

--- a/Exiled.API/Features/Door.cs
+++ b/Exiled.API/Features/Door.cs
@@ -42,7 +42,8 @@ namespace Exiled.API.Features
         /// <param name="room">The <see cref="Room"/> for this door.</param>
         public Door(DoorVariant door, Room room)
         {
-            DoorVariantToDoor.Add(door, this);
+            if (room != null)
+                DoorVariantToDoor.Add(door, this);
             Base = door;
             Room = room;
             Type = GetDoorType();

--- a/Exiled.API/Features/Items/Consumable.cs
+++ b/Exiled.API/Features/Items/Consumable.cs
@@ -37,5 +37,14 @@ namespace Exiled.API.Features.Items
         /// Gets the <see cref="BaseConsumable"/> that this class is encapsulating.
         /// </summary>
         public new BaseConsumable Base { get; }
+
+        /// <inheritdoc/>
+        internal override void ChangeOwner(Player oldOwner, Player newOwner)
+        {
+            if (oldOwner != Server.Host)
+                Base.OnRemoved(null);
+
+            Base.Owner = newOwner.ReferenceHub;
+        }
     }
 }

--- a/Exiled.API/Features/Items/Item.cs
+++ b/Exiled.API/Features/Items/Item.cs
@@ -238,7 +238,8 @@ namespace Exiled.API.Features.Items
         /// <returns>The <see cref="Item"/> created. This can be cast as a subclass.</returns>
         public static Item Create(ItemType type, Player owner = null) => type switch
         {
-            ItemType.Adrenaline or ItemType.Medkit or ItemType.Painkillers or ItemType.SCP500 or ItemType.SCP207 or ItemType.SCP268 => new Usable(type),
+            ItemType.SCP268 => new Usable(type),
+            ItemType.Adrenaline or ItemType.Medkit or ItemType.Painkillers or ItemType.SCP500 or ItemType.SCP207 or ItemType.SCP1853 => new Consumable(type),
             ItemType.SCP244a or ItemType.SCP244b => new Scp244(type),
             ItemType.Ammo9x19 or ItemType.Ammo12gauge or ItemType.Ammo44cal or ItemType.Ammo556x45 or ItemType.Ammo762x39 => new Ammo(type),
             ItemType.Flashlight => new Flashlight(),

--- a/Exiled.Events/EventArgs/Map/SpawningItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/Map/SpawningItemEventArgs.cs
@@ -53,6 +53,7 @@ namespace Exiled.Events.EventArgs.Map
         /// <remarks>
         ///     Works only when <see cref="ShouldInitiallySpawn"/> is false.
         ///     null when <see cref="ShouldInitiallySpawn"/> is true.
+        ///     Can be not fully initialized.
         /// </remarks>
         public Door TriggerDoor { get; set; }
 

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -35,7 +35,7 @@ namespace Exiled.Events.Patches.Events.Map
 
             LocalBuilder door = generator.DeclareLocal(typeof(DoorVariant));
             LocalBuilder initiallySpawn = generator.DeclareLocal(typeof(bool));
-            LocalBuilder ev = generator.DeclareLocal(typeof(SpawningItem));
+            LocalBuilder ev = generator.DeclareLocal(typeof(SpawningItemEventArgs));
 
             Label skip = generator.DefineLabel();
             Label doorSpawn = generator.DefineLabel();


### PR DESCRIPTION
- Fixed  `player::AddItem` for consumables [bug report](https://discord.com/channels/656673194693885975/1059864187557396491)
- Fixed my self skill issue about doors init(`SpawningItem` event calls before `Map::GenerateCache`, so phantom doors was added to list, also in future i planned remove cache methods, for better patches usage) 